### PR TITLE
Make two behavior extending systems run for authority only.

### DIFF
--- a/src/main/java/org/terasology/minion/move/MinionMoveSystem.java
+++ b/src/main/java/org/terasology/minion/move/MinionMoveSystem.java
@@ -21,6 +21,7 @@ import org.terasology.entitySystem.entity.lifecycleEvents.BeforeDeactivateCompon
 import org.terasology.entitySystem.entity.lifecycleEvents.OnActivatedComponent;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.logic.characters.events.HorizontalCollisionEvent;
 import org.terasology.logic.characters.events.OnEnterBlockEvent;
@@ -35,7 +36,7 @@ import java.util.Set;
 /**
  * Created by synopia on 02.02.14.
  */
-@RegisterSystem
+@RegisterSystem(RegisterMode.AUTHORITY)
 public class MinionMoveSystem extends BaseComponentSystem {
     @In
     private PathfinderSystem pathfinderSystem;

--- a/src/main/java/org/terasology/pathfinding/componentSystem/PathfinderSystem.java
+++ b/src/main/java/org/terasology/pathfinding/componentSystem/PathfinderSystem.java
@@ -20,6 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.math.Vector3i;
 import org.terasology.navgraph.NavGraphSystem;
@@ -49,7 +50,7 @@ import java.util.List;
  *
  * @author synopia
  */
-@RegisterSystem
+@RegisterSystem(RegisterMode.AUTHORITY)
 @Share(value = PathfinderSystem.class)
 public class PathfinderSystem extends BaseComponentSystem {
 


### PR DESCRIPTION
Reasoning: Engine will soon run behaviors only as authority.

See MovingBlocks/Terasology#1440
