### PR TITLE
Use new asset library that will be introduced by pull request #1740

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -1,13 +1,13 @@
 {
     "id" : "Pathfinding",
-    "version" : "0.1.0",
+    "version" : "0.1.1-SNAPSHOT",
     "author" : "synopia",
     "displayName" : "Pathfinding framework",
     "description" : "A pathfinding module mainly meant as a library/framework for other modules",
     "dependencies" : [
             {
                 "id" : "Core",
-                "minVersion" : "0.53.1"
+                "minVersion" : "0.54.0"
             }
     ],
     "isServerSideOnly" : true

--- a/src/main/java/org/terasology/grid/renderers/DefaultBlockRenderer.java
+++ b/src/main/java/org/terasology/grid/renderers/DefaultBlockRenderer.java
@@ -31,7 +31,7 @@ import org.terasology.rendering.nui.ScaleMode;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockPart;
-import org.terasology.world.block.loader.WorldAtlas;
+import org.terasology.world.block.tiles.WorldAtlas;
 
 /**
  * Created by synopia on 12.02.14.
@@ -49,7 +49,7 @@ public class DefaultBlockRenderer extends BaseComponentSystem implements BlockRe
 
     @Override
     public void initialise() {
-        terrainTex = Assets.getTexture("engine:terrain");
+        terrainTex = Assets.getTexture("engine:terrain").get();
         relativeTileSize = 0.0625f;
     }
 

--- a/src/main/java/org/terasology/pathfinding/PathfinderTestGenerator.java
+++ b/src/main/java/org/terasology/pathfinding/PathfinderTestGenerator.java
@@ -50,8 +50,9 @@ public class PathfinderTestGenerator implements ChunkGenerationPass {
 
     @Override
     public void generateChunk(CoreChunk chunk) {
-        air = BlockManager.getAir();
-        ground = CoreRegistry.get(BlockManager.class).getBlock("core:Dirt");
+        BlockManager blockManager = CoreRegistry.get(BlockManager.class);
+        air = blockManager.getBlock(BlockManager.AIR_ID);
+        ground = blockManager.getBlock("core:Dirt");
 
         generateLevel(chunk, 50);
 

--- a/src/main/java/org/terasology/pathfinding/PathfinderTestWorldMapGenerator.java
+++ b/src/main/java/org/terasology/pathfinding/PathfinderTestWorldMapGenerator.java
@@ -19,9 +19,11 @@ import org.terasology.core.world.generator.AbstractBaseWorldGenerator;
 import org.terasology.core.world.generator.facetProviders.FlatSurfaceHeightProvider;
 import org.terasology.core.world.generator.facetProviders.SeaLevelProvider;
 import org.terasology.engine.SimpleUri;
+import org.terasology.registry.CoreRegistry;
 import org.terasology.world.generation.World;
 import org.terasology.world.generation.WorldBuilder;
 import org.terasology.world.generator.RegisterWorldGenerator;
+import org.terasology.world.generator.plugin.WorldGeneratorPluginLibrary;
 
 /**
  * @author synopia
@@ -42,7 +44,7 @@ public class PathfinderTestWorldMapGenerator extends AbstractBaseWorldGenerator 
 
     @Override
     public void setWorldSeed(String seed) {
-        world = new WorldBuilder(0)
+        world = new WorldBuilder(CoreRegistry.get(WorldGeneratorPluginLibrary.class))
                 .addProvider(new FlatSurfaceHeightProvider(50))
                 .addProvider(new SeaLevelProvider(2))
                 .build();

--- a/src/main/java/org/terasology/pathfinding/componentSystem/PathRenderSystem.java
+++ b/src/main/java/org/terasology/pathfinding/componentSystem/PathRenderSystem.java
@@ -38,7 +38,7 @@ public class PathRenderSystem extends BaseComponentSystem implements RenderSyste
 
     @Override
     public void initialise() {
-        selectionRenderer = new BlockSelectionRenderer(Assets.getTexture("engine:selection"));
+        selectionRenderer = new BlockSelectionRenderer(Assets.getTexture("engine:selection").get());
     }
 
     public void addPath(Path path) {

--- a/src/main/java/org/terasology/work/WorkRenderSystem.java
+++ b/src/main/java/org/terasology/work/WorkRenderSystem.java
@@ -40,7 +40,7 @@ public class WorkRenderSystem extends BaseComponentSystem implements RenderSyste
 
     @Override
     public void initialise() {
-        selectionRenderer = new BlockSelectionRenderer(Assets.getTexture("engine:selection"));
+        selectionRenderer = new BlockSelectionRenderer(Assets.getTexture("engine:selection").get());
     }
 
     @Override

--- a/src/main/java/org/terasology/work/systems/RemoveBlock.java
+++ b/src/main/java/org/terasology/work/systems/RemoveBlock.java
@@ -55,6 +55,8 @@ public class RemoveBlock extends BaseComponentSystem implements Work, ComponentS
     private WorldProvider worldProvider;
     @In
     private WorkFactory workFactory;
+    @In
+    private BlockManager blockManager;
 
     private final SimpleUri uri;
 
@@ -105,7 +107,8 @@ public class RemoveBlock extends BaseComponentSystem implements Work, ComponentS
     @Override
     public void letMinionWork(EntityRef block, EntityRef minion) {
         block.removeComponent(WorkTargetComponent.class);
-        worldProvider.setBlock(block.getComponent(BlockComponent.class).getPosition(), BlockManager.getAir());
+        Block air = blockManager.getBlock(BlockManager.AIR_ID);
+        worldProvider.setBlock(block.getComponent(BlockComponent.class).getPosition(), air);
     }
 
     @Override

--- a/src/test/java/org/terasology/TextWorldBuilder.java
+++ b/src/test/java/org/terasology/TextWorldBuilder.java
@@ -33,10 +33,13 @@ public class TextWorldBuilder {
     private int sizeZ;
     private WorldProvider world;
     private Block ground;
+    private Block air;
 
     public TextWorldBuilder(WorldProvidingHeadlessEnvironment environment) {
         world = CoreRegistry.get(WorldProvider.class);
-        this.ground = environment.registerBlock("Core:Dirt", new Block(), false);
+        BlockManager blockManager = CoreRegistry.get(BlockManager.class);
+        this.ground = blockManager.getBlock("Core:Dirt");
+        this.air = blockManager.getBlock(BlockManager.AIR_ID);
     }
 
     public void setGround(int x, int y, int z) {
@@ -44,7 +47,7 @@ public class TextWorldBuilder {
     }
 
     public void setAir(int x, int y, int z) {
-        world.setBlock(new Vector3i(x, y, z), BlockManager.getAir());
+        world.setBlock(new Vector3i(x, y, z), air);
     }
 
     public void setGround(String... lines) {

--- a/src/test/java/org/terasology/WorldProvidingHeadlessEnvironment.java
+++ b/src/test/java/org/terasology/WorldProvidingHeadlessEnvironment.java
@@ -15,18 +15,10 @@
  */
 package org.terasology;
 
+import org.terasology.naming.Name;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.world.BlockEntityRegistry;
 import org.terasology.world.WorldProvider;
-import org.terasology.world.block.Block;
-import org.terasology.world.block.BlockManager;
-import org.terasology.world.block.BlockUri;
-import org.terasology.world.block.family.AttachedToSurfaceFamilyFactory;
-import org.terasology.world.block.family.DefaultBlockFamilyFactoryRegistry;
-import org.terasology.world.block.family.HorizontalBlockFamilyFactory;
-import org.terasology.world.block.family.SymmetricFamily;
-import org.terasology.world.block.internal.BlockManagerImpl;
-import org.terasology.world.block.loader.NullWorldAtlas;
 import org.terasology.world.generator.WorldGenerator;
 import org.terasology.world.internal.EntityAwareWorldProvider;
 import org.terasology.world.internal.WorldProviderCore;
@@ -36,8 +28,10 @@ import org.terasology.world.internal.WorldProviderWrapper;
  * Created by synopia on 10.02.14.
  */
 public class WorldProvidingHeadlessEnvironment extends HeadlessEnvironment {
-    private BlockManagerImpl blockManager;
-    private short nextBlockId = 100;
+
+    public WorldProvidingHeadlessEnvironment(Name... modules) {
+        super(modules);
+    }
 
     public void setupWorldProvider(WorldGenerator generator) {
         generator.initialize();
@@ -47,27 +41,5 @@ public class WorldProvidingHeadlessEnvironment extends HeadlessEnvironment {
         CoreRegistry.put(BlockEntityRegistry.class, new EntityAwareWorldProvider(stub));
     }
 
-    @Override
-    protected void setupBlockManager() {
-        DefaultBlockFamilyFactoryRegistry blockFamilyFactoryRegistry = new DefaultBlockFamilyFactoryRegistry();
-        blockFamilyFactoryRegistry.setBlockFamilyFactory("horizontal", new HorizontalBlockFamilyFactory());
-        blockFamilyFactoryRegistry.setBlockFamilyFactory("alignToSurface", new AttachedToSurfaceFamilyFactory());
-        blockManager = new BlockManagerImpl(new NullWorldAtlas(), blockFamilyFactoryRegistry);
-        CoreRegistry.put(BlockManager.class, blockManager);
-    }
 
-    public Block registerBlock(String uri, Block block, boolean penetrable) {
-        block.setPenetrable(penetrable);
-        return registerBlock(uri, block);
-    }
-
-    public Block registerBlock(String uri, Block block) {
-        block.setId(nextBlockId);
-        block.setUri(new BlockUri(uri));
-        blockManager.addBlockFamily(new SymmetricFamily(block.getURI(), block), true);
-
-        nextBlockId++;
-
-        return block;
-    }
 }

--- a/src/test/java/org/terasology/navgraph/ConnectNavGraphChunkTest.java
+++ b/src/test/java/org/terasology/navgraph/ConnectNavGraphChunkTest.java
@@ -23,6 +23,7 @@ import org.terasology.WorldProvidingHeadlessEnvironment;
 import org.terasology.core.world.generator.AbstractBaseWorldGenerator;
 import org.terasology.engine.SimpleUri;
 import org.terasology.math.geom.Vector3i;
+import org.terasology.naming.Name;
 import org.terasology.pathfinding.PathfinderTestGenerator;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.world.WorldProvider;
@@ -136,7 +137,7 @@ public class ConnectNavGraphChunkTest {
 
     @Before
     public void setup() {
-        WorldProvidingHeadlessEnvironment env = new WorldProvidingHeadlessEnvironment();
+        WorldProvidingHeadlessEnvironment env = new WorldProvidingHeadlessEnvironment(new Name("Pathfinding"));
         env.setupWorldProvider(new AbstractBaseWorldGenerator(new SimpleUri("")) {
             @Override
             public void initialize() {

--- a/src/test/java/org/terasology/navgraph/ContourFinderTest.java
+++ b/src/test/java/org/terasology/navgraph/ContourFinderTest.java
@@ -22,6 +22,7 @@ import org.terasology.WorldProvidingHeadlessEnvironment;
 import org.terasology.core.world.generator.AbstractBaseWorldGenerator;
 import org.terasology.engine.SimpleUri;
 import org.terasology.math.geom.Vector3i;
+import org.terasology.naming.Name;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.world.WorldProvider;
 
@@ -417,7 +418,7 @@ public class ContourFinderTest {
     }
 
     private void assertContour(String[] ground, String[] contour) {
-        WorldProvidingHeadlessEnvironment env = new WorldProvidingHeadlessEnvironment();
+        WorldProvidingHeadlessEnvironment env = new WorldProvidingHeadlessEnvironment(new Name("Pathfinding"));
         env.setupWorldProvider(new AbstractBaseWorldGenerator(new SimpleUri("")) {
             @Override
             public void initialize() {

--- a/src/test/java/org/terasology/navgraph/FloorFinderTest.java
+++ b/src/test/java/org/terasology/navgraph/FloorFinderTest.java
@@ -22,6 +22,7 @@ import org.terasology.WorldProvidingHeadlessEnvironment;
 import org.terasology.core.world.generator.AbstractBaseWorldGenerator;
 import org.terasology.engine.SimpleUri;
 import org.terasology.math.geom.Vector3i;
+import org.terasology.naming.Name;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.world.WorldProvider;
 
@@ -313,7 +314,7 @@ public class FloorFinderTest {
     }
 
     private void assertFloors(String[] data, String[] floors, String[] contour, int[][] connections) {
-        WorldProvidingHeadlessEnvironment env = new WorldProvidingHeadlessEnvironment();
+        WorldProvidingHeadlessEnvironment env = new WorldProvidingHeadlessEnvironment(new Name("Pathfinding"));
         env.setupWorldProvider(new AbstractBaseWorldGenerator(new SimpleUri("")) {
             @Override
             public void initialize() {

--- a/src/test/java/org/terasology/navgraph/RegionFinderTest.java
+++ b/src/test/java/org/terasology/navgraph/RegionFinderTest.java
@@ -22,6 +22,7 @@ import org.terasology.WorldProvidingHeadlessEnvironment;
 import org.terasology.core.world.generator.AbstractBaseWorldGenerator;
 import org.terasology.engine.SimpleUri;
 import org.terasology.math.geom.Vector3i;
+import org.terasology.naming.Name;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.world.WorldProvider;
 
@@ -155,7 +156,7 @@ public class RegionFinderTest {
     }
 
     private void assertRegions(String[] data, String[] regions, int[][] connections) {
-        WorldProvidingHeadlessEnvironment env = new WorldProvidingHeadlessEnvironment();
+        WorldProvidingHeadlessEnvironment env = new WorldProvidingHeadlessEnvironment(new Name("Pathfinding"));
         env.setupWorldProvider(new AbstractBaseWorldGenerator(new SimpleUri("")) {
             @Override
             public void initialize() {

--- a/src/test/java/org/terasology/navgraph/WalkableBlockFinderTest.java
+++ b/src/test/java/org/terasology/navgraph/WalkableBlockFinderTest.java
@@ -23,6 +23,7 @@ import org.terasology.WorldProvidingHeadlessEnvironment;
 import org.terasology.core.world.generator.AbstractBaseWorldGenerator;
 import org.terasology.engine.SimpleUri;
 import org.terasology.math.geom.Vector3i;
+import org.terasology.naming.Name;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.world.WorldProvider;
 
@@ -230,7 +231,7 @@ public class WalkableBlockFinderTest {
 
     @Before
     public void setup() {
-        WorldProvidingHeadlessEnvironment env = new WorldProvidingHeadlessEnvironment();
+        WorldProvidingHeadlessEnvironment env = new WorldProvidingHeadlessEnvironment(new Name("Pathfinding"));
         env.setupWorldProvider(new AbstractBaseWorldGenerator(new SimpleUri("")) {
             @Override
             public void initialize() {

--- a/src/test/java/org/terasology/pathfinding/HAStarLoSTest.java
+++ b/src/test/java/org/terasology/pathfinding/HAStarLoSTest.java
@@ -22,6 +22,7 @@ import org.terasology.WorldProvidingHeadlessEnvironment;
 import org.terasology.core.world.generator.AbstractBaseWorldGenerator;
 import org.terasology.engine.SimpleUri;
 import org.terasology.math.geom.Vector3i;
+import org.terasology.naming.Name;
 import org.terasology.navgraph.NavGraphChunk;
 import org.terasology.navgraph.WalkableBlock;
 import org.terasology.pathfinding.model.HAStar;
@@ -140,7 +141,7 @@ public class HAStarLoSTest {
     }
 
     private void executeExample(String[] ground, String[] pathData) {
-        WorldProvidingHeadlessEnvironment env = new WorldProvidingHeadlessEnvironment();
+        WorldProvidingHeadlessEnvironment env = new WorldProvidingHeadlessEnvironment(new Name("Pathfinding"));
         env.setupWorldProvider(new AbstractBaseWorldGenerator(new SimpleUri("")) {
             @Override
             public void initialize() {

--- a/src/test/java/org/terasology/pathfinding/HAStarTest.java
+++ b/src/test/java/org/terasology/pathfinding/HAStarTest.java
@@ -22,6 +22,7 @@ import org.terasology.WorldProvidingHeadlessEnvironment;
 import org.terasology.core.world.generator.AbstractBaseWorldGenerator;
 import org.terasology.engine.SimpleUri;
 import org.terasology.math.geom.Vector3i;
+import org.terasology.naming.Name;
 import org.terasology.navgraph.NavGraphChunk;
 import org.terasology.navgraph.WalkableBlock;
 import org.terasology.pathfinding.model.HAStar;
@@ -116,7 +117,7 @@ public class HAStarTest {
     }
 
     private void executeExample(String[] ground, String[] pathData) {
-        WorldProvidingHeadlessEnvironment env = new WorldProvidingHeadlessEnvironment();
+        WorldProvidingHeadlessEnvironment env = new WorldProvidingHeadlessEnvironment(new Name("Pathfinding"));
         env.setupWorldProvider(new AbstractBaseWorldGenerator(new SimpleUri("")) {
             @Override
             public void initialize() {

--- a/src/test/java/org/terasology/pathfinding/PathDebugger.java
+++ b/src/test/java/org/terasology/pathfinding/PathDebugger.java
@@ -30,7 +30,6 @@ import org.terasology.pathfinding.model.LineOfSight;
 import org.terasology.pathfinding.model.LineOfSight2d;
 import org.terasology.pathfinding.model.Path;
 import org.terasology.registry.CoreRegistry;
-import org.terasology.world.block.Block;
 
 import javax.swing.JFrame;
 import javax.swing.JPanel;
@@ -68,7 +67,6 @@ public class PathDebugger extends JFrame {
                 register(new PathfinderTestGenerator(true, true));
             }
         });
-        env.registerBlock("Core:Dirt", new Block(), false);
 
         mapWidth = 160;
         mapHeight = 100;

--- a/src/test/java/org/terasology/pathfinding/PathfinderSystemTest.java
+++ b/src/test/java/org/terasology/pathfinding/PathfinderSystemTest.java
@@ -31,6 +31,7 @@ import org.terasology.entitySystem.event.internal.EventReceiver;
 import org.terasology.entitySystem.event.internal.EventSystem;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.minion.move.MinionMoveComponent;
+import org.terasology.naming.Name;
 import org.terasology.navgraph.NavGraphSystem;
 import org.terasology.pathfinding.componentSystem.PathReadyEvent;
 import org.terasology.pathfinding.componentSystem.PathfinderSystem;
@@ -107,7 +108,7 @@ public class PathfinderSystemTest {
 
     @Before
     public void setup() {
-        environment = new WorldProvidingHeadlessEnvironment();
+        environment = new WorldProvidingHeadlessEnvironment(new Name("Pathfinding"));
         environment.setupWorldProvider(new AbstractBaseWorldGenerator(new SimpleUri("")) {
             @Override
             public void initialize() {

--- a/src/test/java/org/terasology/pathfinding/PathfinderTest.java
+++ b/src/test/java/org/terasology/pathfinding/PathfinderTest.java
@@ -23,6 +23,7 @@ import org.terasology.WorldProvidingHeadlessEnvironment;
 import org.terasology.core.world.generator.AbstractBaseWorldGenerator;
 import org.terasology.engine.SimpleUri;
 import org.terasology.math.geom.Vector3i;
+import org.terasology.naming.Name;
 import org.terasology.navgraph.NavGraphChunk;
 import org.terasology.navgraph.NavGraphSystem;
 import org.terasology.navgraph.WalkableBlock;
@@ -102,7 +103,7 @@ public class PathfinderTest {
 
     @Before
     public void setup() {
-        WorldProvidingHeadlessEnvironment env = new WorldProvidingHeadlessEnvironment();
+        WorldProvidingHeadlessEnvironment env = new WorldProvidingHeadlessEnvironment(new Name("Pathfinding"));
         env.setupWorldProvider(new AbstractBaseWorldGenerator(new SimpleUri("")) {
             @Override
             public void initialize() {

--- a/src/test/java/org/terasology/work/ClusterDebugger.java
+++ b/src/test/java/org/terasology/work/ClusterDebugger.java
@@ -31,6 +31,7 @@ import org.terasology.math.Region3i;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.minion.move.MinionMoveComponent;
 import org.terasology.monitoring.PerformanceMonitor;
+import org.terasology.naming.Name;
 import org.terasology.navgraph.Entrance;
 import org.terasology.navgraph.Floor;
 import org.terasology.navgraph.NavGraphSystem;
@@ -41,7 +42,6 @@ import org.terasology.registry.CoreRegistry;
 import org.terasology.rendering.nui.properties.OneOfProviderFactory;
 import org.terasology.work.kmeans.Cluster;
 import org.terasology.work.systems.WalkToBlock;
-import org.terasology.world.block.Block;
 
 import javax.swing.JFrame;
 import javax.swing.JPanel;
@@ -76,14 +76,13 @@ public class ClusterDebugger extends JFrame {
     private final Object mutex = new Object();
 
     public ClusterDebugger() throws HeadlessException {
-        env = new WorldProvidingHeadlessEnvironment();
+        env = new WorldProvidingHeadlessEnvironment(new Name("Pathfinding"));
         env.setupWorldProvider(new AbstractBaseWorldGenerator(new SimpleUri("")) {
             @Override
             public void initialize() {
                 register(new PathfinderTestGenerator(true, true));
             }
         });
-        env.registerBlock("Core:Dirt", new Block(), false);
 
         entityManager = CoreRegistry.get(EntityManager.class);
         mapWidth = 160;


### PR DESCRIPTION
Untested migration to new asset library needed once MovingBlocks/Terasology#1740 get merged.

Instead of registering blocks the unit tests now simply load the Core module properly.

@synopia I fixed most of the unit tests but  PathfinderTest#testStairs is failing. Before I debug deeper it would be cool if you could have look.