### PR TITLE
fix does-not-override error in MapWorldProvider

### DIFF
--- a/src/test/java/org/terasology/MapWorldProvider.java
+++ b/src/test/java/org/terasology/MapWorldProvider.java
@@ -40,6 +40,7 @@ import org.terasology.world.time.WorldTimeImpl;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -88,6 +89,15 @@ public class MapWorldProvider implements WorldProviderCore {
     @Override
     public Block setBlock(Vector3i pos, Block type) {
         return blocks.put(pos, type);
+    }
+
+    @Override
+    public Map<Vector3i, Block> setBlocks(Map<Vector3i, Block> blocksToSet) {
+        Map<Vector3i, Block> result = new HashMap<>();
+        for(Map.Entry<Vector3i, Block> entry : blocksToSet.entrySet()) {
+            result.put(entry.getKey(), blocks.put(entry.getKey(), entry.getValue()));
+        }
+        return result;
     }
 
     @Override


### PR DESCRIPTION
Caused by https://github.com/MovingBlocks/Terasology/commit/a2bf662c93171eb630b264a24afac74a428fa7c4

Terasology/modules/Pathfinding/src/test/java/org/terasology/MapWorldProvider.java

Error:(49, 8) java: org.terasology.MapWorldProvider is not abstract and does
not override abstract method
setBlocks(java.util.Map<org.terasology.math.geom.Vector3i,org.terasology.world.block.Block>)
in org.terasology.world.internal.WorldProviderCore

---

Still needs testing, but now it compiles against develop