### PR TITLE
Add movement nodes and component from GooeysQuests module

### DIFF
--- a/assets/behaviors/attackPlayerToFollow.behavior
+++ b/assets/behaviors/attackPlayerToFollow.behavior
@@ -1,0 +1,144 @@
+{
+  "model": {
+    "nodeType": "engine:SequenceNode",
+    "nodeId": 0,
+    "node": {
+      "children": [
+        {
+          "nodeType": "Pathfinding:ContinueFollowingCheckNode",
+          "nodeId": 1,
+          "node": {
+            "minDistance": 0.90000004,
+            "maxDistance": 100.0
+          }
+        },
+        {
+          "nodeType": "engine:WrapperNode",
+          "nodeId": 2,
+          "node": {
+            "child": {
+              "nodeType": "engine:ParallelNode",
+              "nodeId": 3,
+              "node": {
+                "successPolicy": "RequireAll",
+                "failurePolicy": "RequireOne",
+                "children": [
+                  {
+                    "nodeType": "engine:RepeatNode",
+                    "nodeId": 4,
+                    "node": {
+                      "child": {
+                        "nodeType": "Pathfinding:ContinueFollowingCheckNode",
+                        "nodeId": 5,
+                        "node": {
+                          "minDistance": 1.2,
+                          "maxDistance": 100.0
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "nodeType": "Pathfinding:FollowNode",
+                    "nodeId": 6,
+                    "node": {}
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "nodeType": "engine:WrapperNode",
+          "nodeId": 7,
+          "node": {
+            "child": {
+              "nodeType": "engine:RepeatNode",
+              "nodeId": 8,
+              "node": {
+                "child": {
+                  "nodeType": "engine:SequenceNode",
+                  "nodeId": 9,
+                  "node": {
+                    "children": [
+                      {
+                        "nodeType": "Pathfinding:ContinueFollowingCheckNode",
+                        "nodeId": 10,
+                        "node": {
+                          "minDistance": 0.0,
+                          "maxDistance": 1.2
+                        }
+                      },
+                      {
+                        "nodeType": "engine:SetAnimationNode",
+                        "nodeId": 11,
+                        "node": {
+                          "play": "engine:Walk.animationPool",
+                          "loop": "Pathfinding:MeleeAttack.animationPool"
+                        }
+                      },
+                      {
+                        "nodeType": "engine:WrapperNode",
+                        "nodeId": 12,
+                        "node": {
+                          "child": {
+                            "nodeType": "engine:TimerNode",
+                            "nodeId": 13,
+                            "node": {
+                              "time": 0.5
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "nodeType": "engine:WrapperNode",
+                        "nodeId": 14,
+                        "node": {
+                          "child": {
+                            "nodeType": "engine:SequenceNode",
+                            "nodeId": 15,
+                            "node": {
+                              "children": [
+                                {
+                                  "nodeType": "Pathfinding:ContinueFollowingCheckNode",
+                                  "nodeId": 16,
+                                  "node": {
+                                    "minDistance": 0.0,
+                                    "maxDistance": 1.2
+                                  }
+                                },
+                                {
+                                  "nodeType": "Pathfinding:DamageFollowedPlayerNode",
+                                  "nodeId": 17,
+                                  "node": {
+                                    "damage": 40
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "nodeType": "engine:WrapperNode",
+                        "nodeId": 18,
+                        "node": {
+                          "child": {
+                            "nodeType": "engine:TimerNode",
+                            "nodeId": 19,
+                            "node": {
+                              "time": 0.5
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/assets/behaviors/hostile.behavior
+++ b/assets/behaviors/hostile.behavior
@@ -1,0 +1,44 @@
+{
+  "model": {
+    "nodeType": "engine:RepeatNode",
+    "nodeId": 0,
+    "node": {
+      "child": {
+        "nodeType": "engine:WrapperNode",
+        "nodeId": 1,
+        "node": {
+          "child": {
+            "nodeType": "engine:SequenceNode",
+            "nodeId": 2,
+            "node": {
+              "children": [
+                {
+                  "nodeType": "Pathfinding:FollowPlayerWithinRangeNode",
+                  "nodeId": 3,
+                  "node": {
+                    "maxDistance": 15.8
+                  }
+                },
+                {
+                  "nodeType": "engine:SelectorNode",
+                  "nodeId": 4,
+                  "node": {
+                    "children": [
+                      {
+                        "nodeType": "engine:LookupNode",
+                        "nodeId": 5,
+                        "node": {
+                          "tree": "Pathfinding:attackPlayerToFollow"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/assets/behaviors/moveToPlayerToFollow.behavior
+++ b/assets/behaviors/moveToPlayerToFollow.behavior
@@ -1,0 +1,67 @@
+{
+  "model": {
+    "nodeType": "engine:SequenceNode",
+    "nodeId": 0,
+    "node": {
+      "children": [
+        {
+          "nodeType": "Pathfinding:ContinueFollowingCheckNode",
+          "nodeId": 1,
+          "node": {
+            "minDistance": 5.0
+          }
+        },
+        {
+          "nodeType": "engine:SetAnimationNode",
+          "nodeId": 2,
+          "node": {
+            "play": "engine:Walk.animationPool",
+            "loop": "engine:Walk.animationPool"
+          }
+        },
+        {
+          "nodeType": "engine:WrapperNode",
+          "nodeId": 3,
+          "node": {
+            "child": {
+              "nodeType": "engine:ParallelNode",
+              "nodeId": 4,
+              "node": {
+                "successPolicy": "RequireAll",
+                "failurePolicy": "RequireOne",
+                "children": [
+                  {
+                    "nodeType": "engine:RepeatNode",
+                    "nodeId": 5,
+                    "node": {
+                      "child": {
+                        "nodeType": "Pathfinding:ContinueFollowingCheckNode",
+                        "nodeId": 6,
+                        "node": {
+                          "minDistance": 3.0
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "nodeType": "Pathfinding:FollowNode",
+                    "nodeId": 7,
+                    "node": {}
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "nodeType": "engine:SetAnimationNode",
+          "nodeId": 8,
+          "node": {
+            "play": "engine:Stand.animationPool",
+            "loop": "engine:Stand.animationPool"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/assets/prefabs/behaviorNodes/Follow.prefab
+++ b/assets/prefabs/behaviorNodes/Follow.prefab
@@ -1,0 +1,11 @@
+{
+  "BehaviorNode" : {
+    "type"      : "FollowNode",
+    "name"      : "Follow",
+    "category"  : "gooey",
+    "shape"     : "rect",
+    "color"     : [180, 180, 180, 255],
+    "description": "Make the actor use pathfinding algorithms to follow the target entity. \nSUCCESS: never \nFAILURE: When it was no longer possible to follow the entity.",
+    "textColor" : [  0,   0,   0, 255]
+  }
+}

--- a/assets/prefabs/behaviorNodes/continueFollowingCheck.prefab
+++ b/assets/prefabs/behaviorNodes/continueFollowingCheck.prefab
@@ -1,0 +1,11 @@
+{
+  "BehaviorNode" : {
+    "type"      : "ContinueFollowingCheckNode",
+    "name"      : "Can Follow",
+    "category"  : "gooey",
+    "shape"     : "rect",
+    "color"     : [180, 180, 180, 255],
+    "description": "Fails if there is no FollowComponent with a target to follow that is still farer away than the specified minDistance. \nSUCCESS: When there is a target to follow\nFAILURE: When there is nothing to follow when the actor is already close enough",
+    "textColor" : [  0,   0,   0, 255]
+  }
+}

--- a/assets/prefabs/behaviorNodes/damageFollowedPlayer.prefab
+++ b/assets/prefabs/behaviorNodes/damageFollowedPlayer.prefab
@@ -1,0 +1,11 @@
+{
+  "BehaviorNode" : {
+    "type"      : "DamageFollowedPlayerNode",
+    "name"      : "Damage followed entity",
+    "category"  : "gooey",
+    "shape"     : "rect",
+    "color"     : [180, 180, 180, 255],
+    "description": "Deals damage to the followed entity. \nSUCCESS: When damage has been dealt.\nFAILURE: When it was not possible",
+    "textColor" : [  0,   0,   0, 255]
+  }
+}

--- a/assets/prefabs/behaviorNodes/followPlayerWithinRange.prefab
+++ b/assets/prefabs/behaviorNodes/followPlayerWithinRange.prefab
@@ -1,0 +1,11 @@
+{
+  "BehaviorNode" : {
+    "type"      : "FollowPlayerWithinRangeNode",
+    "name"      : "Follow player within range",
+    "category"  : "gooey",
+    "shape"     : "rect",
+    "color"     : [180, 180, 180, 255],
+    "description": "Sets the Followcomponent to a player within the given distance limit. \nSUCCESS: When the target to follow has been set.\nFAILURE: When it was not possible",
+    "textColor" : [  0,   0,   0, 255]
+  }
+}

--- a/assets/prefabs/behaviorNodes/setTargetToEntityToFollow.prefab
+++ b/assets/prefabs/behaviorNodes/setTargetToEntityToFollow.prefab
@@ -1,0 +1,11 @@
+{
+  "BehaviorNode" : {
+    "type"      : "SetTargetToEntityToFollowNode",
+    "name"      : "Set Target to Follow",
+    "category"  : "gooey",
+    "shape"     : "rect",
+    "color"     : [180, 180, 180, 255],
+    "description": "Sets the target of the MinionMoveComponent to the entity Specified by the FollowComponent. \nSUCCESS: When the target has been set.\nFAILURE: When it was not possible",
+    "textColor" : [  0,   0,   0, 255]
+  }
+}

--- a/src/main/java/org/terasology/pathfinding/componentSystem/NPCMovementSystem.java
+++ b/src/main/java/org/terasology/pathfinding/componentSystem/NPCMovementSystem.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.pathfinding.componentSystem;
+
+import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.entity.lifecycleEvents.OnChangedComponent;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
+import org.terasology.logic.characters.CharacterMoveInputEvent;
+import org.terasology.logic.characters.StandComponent;
+import org.terasology.logic.characters.WalkComponent;
+import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.TeraMath;
+import org.terasology.math.geom.Vector3f;
+import org.terasology.minion.move.MinionMoveComponent;
+import org.terasology.pathfinding.components.NPCMovementComponent;
+import org.terasology.registry.In;
+import org.terasology.rendering.assets.animation.MeshAnimation;
+import org.terasology.rendering.logic.SkeletalMeshComponent;
+
+import java.util.List;
+
+/**
+ * Makes entities with the {@link NPCMovementSystem} move to the target specified by {@link NPCMovementComponent}.
+ *
+ * The rotation gets taken from {@link NPCMovementComponent}.
+ *
+ * It is just a proof of concept and will propably be generalized and moved to either pathfinding or engine.
+ */
+@RegisterSystem(RegisterMode.AUTHORITY)
+public class NPCMovementSystem extends BaseComponentSystem implements UpdateSubscriberSystem {
+
+    private static final float MIN_DISTANCE = 0.1f;
+
+
+    @In
+    private EntityManager entityManager;
+
+
+    @Override
+    public void update(float delta) {
+        Iterable<EntityRef> entities = entityManager.getEntitiesWith(NPCMovementComponent.class);
+        for (EntityRef entity: entities) {
+            updateEntitiy(entity, delta);
+        }
+    }
+
+    private void updateEntitiy(EntityRef entity, float delta) {
+        NPCMovementComponent npcMovementComponent = entity.getComponent(NPCMovementComponent.class);
+        Vector3f currentTarget = null;
+        if (npcMovementComponent != null && npcMovementComponent.targetPosition != null ) {
+            currentTarget = npcMovementComponent.targetPosition;
+        }
+        boolean jumpRecommended = false;
+        MinionMoveComponent mnionMovementComponent = entity.getComponent(MinionMoveComponent.class);
+        if (mnionMovementComponent != null && mnionMovementComponent.horizontalCollision) {
+            mnionMovementComponent.horizontalCollision = false;
+            entity.saveComponent(mnionMovementComponent);
+            jumpRecommended = true;
+        }
+        sendInputEvent(entity, currentTarget, jumpRecommended, delta);
+
+    }
+
+    private void sendInputEvent(EntityRef entity, Vector3f currentTarget, boolean jumpRecommended, float delta) {
+        LocationComponent location = entity.getComponent(LocationComponent.class);
+        CharacterMoveInputEvent inputEvent = null;
+        if (currentTarget != null) {
+            Vector3f worldPos = new Vector3f(location.getWorldPosition());
+            Vector3f deltaToTarget = new Vector3f();
+            deltaToTarget.sub(currentTarget, worldPos);
+            float yaw = (float) Math.atan2(deltaToTarget.x, deltaToTarget.z);
+
+            Vector3f drive = new Vector3f();
+            float remainingDistanceSquared = deltaToTarget.x * deltaToTarget.x + deltaToTarget.z * deltaToTarget.z;
+
+            /**
+             * Don't let the character do super mini staps if we are arealdy as good as at the target.
+             */
+            boolean notAtTargetYet = remainingDistanceSquared > MIN_DISTANCE * MIN_DISTANCE;
+            if (notAtTargetYet) {
+                drive.set(deltaToTarget);
+                drive.scale(1.0f / (float) Math.sqrt(remainingDistanceSquared));
+                boolean jumpRequested = jumpRecommended;
+                float requestedYaw = 180f + yaw * TeraMath.RAD_TO_DEG;
+                 inputEvent = new CharacterMoveInputEvent(0, 0, requestedYaw, drive, false,
+                        jumpRequested, (long) (delta * 1000));
+            }
+        }
+
+        // send default input event, as otherwise an interpolation of last movement gets performed
+        if (inputEvent == null) {
+            Vector3f drive = new Vector3f(0.0f, 0.0f, 0.0f);
+            NPCMovementComponent npcMovementComponent = entity.getComponent(NPCMovementComponent.class);
+            float yaw = npcMovementComponent.yaw;;
+            boolean jumpRequested = false;
+            inputEvent = new CharacterMoveInputEvent(0, 0, yaw, drive, false,
+                    jumpRequested, (long) (delta * 1000));
+        }
+
+        entity.send(inputEvent);
+    }
+
+
+
+
+    @ReceiveEvent
+    public void updateAnimation(OnChangedComponent event, EntityRef entity, NPCMovementComponent component) {
+        WalkComponent walkComponent = entity.getComponent(WalkComponent.class);
+        if (walkComponent == null) {
+            return;
+        }
+        StandComponent standComponent = entity.getComponent(StandComponent.class);
+        if (standComponent == null) {
+            return;
+        }
+        SkeletalMeshComponent skeletalMeshComponent = entity.getComponent(SkeletalMeshComponent.class);
+        if (skeletalMeshComponent == null)  {
+            return;
+        }
+        List<MeshAnimation> wantedAnimationPool;
+        if (component.targetPosition != null) {
+            wantedAnimationPool = walkComponent.animationPool;
+        } else {
+            wantedAnimationPool = standComponent.animationPool;
+        }
+        if (wantedAnimationPool.equals(skeletalMeshComponent.animationPool)) {
+            return;
+        }
+        skeletalMeshComponent.animation = null;
+        skeletalMeshComponent.animationPool.clear();
+        skeletalMeshComponent.animationPool.addAll(wantedAnimationPool);
+        skeletalMeshComponent.loop = true;
+        entity.saveComponent(skeletalMeshComponent);
+    }
+
+}

--- a/src/main/java/org/terasology/pathfinding/components/FollowComponent.java
+++ b/src/main/java/org/terasology/pathfinding/components/FollowComponent.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.pathfinding.components;
+
+import org.terasology.entitySystem.Component;
+import org.terasology.entitySystem.entity.EntityRef;
+
+/**
+ * Entities with this component want to follow another entity. Used to make gooey follow the player around if
+ * the player wishes so.
+ */
+public class FollowComponent implements Component {
+    public EntityRef entityToFollow = EntityRef.NULL;
+}

--- a/src/main/java/org/terasology/pathfinding/components/MeleeAttackComponent.java
+++ b/src/main/java/org/terasology/pathfinding/components/MeleeAttackComponent.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.pathfinding.components;
+
+import com.google.common.collect.Lists;
+import org.terasology.entitySystem.Component;
+import org.terasology.rendering.assets.animation.MeshAnimation;
+
+import java.util.List;
+
+/**
+ * The component gets currently only used as container for the melee attack animation.
+ */
+public class MeleeAttackComponent implements Component {
+    /**
+     * A pool of walk animations. It gets currently only used by behavior trees to make a skeletal mesh perform an attack
+     * animation. The animations of the pool will be picked by random. The result is a randomized animation
+     * loop. The same animation can be put multiple times in the pool, so that it will be chosen more frequently.
+     */
+    public List<MeshAnimation> animationPool = Lists.newArrayList();
+
+}

--- a/src/main/java/org/terasology/pathfinding/components/MeleeAttackComponent.java
+++ b/src/main/java/org/terasology/pathfinding/components/MeleeAttackComponent.java
@@ -26,9 +26,9 @@ import java.util.List;
  */
 public class MeleeAttackComponent implements Component {
     /**
-     * A pool of walk animations. It gets currently only used by behavior trees to make a skeletal mesh perform an attack
-     * animation. The animations of the pool will be picked by random. The result is a randomized animation
-     * loop. The same animation can be put multiple times in the pool, so that it will be chosen more frequently.
+     * A pool of attack animations. The animations of the pool will be picked by random. The result is a randomized
+     * animation loop. The same animation can be put multiple times in the pool, so that it will be chosen more
+     * frequently.
      */
     public List<MeshAnimation> animationPool = Lists.newArrayList();
 

--- a/src/main/java/org/terasology/pathfinding/components/NPCMovementComponent.java
+++ b/src/main/java/org/terasology/pathfinding/components/NPCMovementComponent.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.pathfinding.components;
+
+import org.terasology.entitySystem.Component;
+import org.terasology.math.geom.Vector3f;
+
+/**
+ * Non player characters should have this component even if they don't move, so that movement input gets simulated fo
+ * them. Otherwise the game will try to predict the character movmeent based on the last movement which leads to strange
+ * behavior.
+ */
+public class NPCMovementComponent implements Component {
+    /**
+     * Angle in degree in which the character will look at. Used to simulate constant yaw input. Calculating it
+     * freshly each time would lead to rounding mistakes that commulate.
+     */
+    public float yaw;
+
+    /**
+     * Position to which the charcter will move to in a straight line. For advanced pathing, a behavior tree should
+     * be used that sets this field to the next waypoint of the calculated path to the target.
+     */
+    public transient Vector3f targetPosition;
+}

--- a/src/main/java/org/terasology/pathfinding/nodes/ContinueFollowingCheckNode.java
+++ b/src/main/java/org/terasology/pathfinding/nodes/ContinueFollowingCheckNode.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.pathfinding.nodes;
+
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.logic.behavior.tree.Node;
+import org.terasology.logic.behavior.tree.Status;
+import org.terasology.logic.behavior.tree.Task;
+import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.geom.Vector3f;
+import org.terasology.pathfinding.componentSystem.PathfinderSystem;
+import org.terasology.pathfinding.components.FollowComponent;
+import org.terasology.registry.In;
+import org.terasology.rendering.nui.properties.Range;
+
+/**
+ * Checks if the actor still wants to move closer to a target specified by a {@link FollowComponent}.
+ */
+public class ContinueFollowingCheckNode extends Node {
+
+    @Range(min = 0, max = 20)
+    private float minDistance = 0.0f;
+
+    @Range(min = 0, max = 100)
+    private float maxDistance = 100.0f;
+
+    @Override
+    public ContinueFollowingCheckTask createTask() {
+        return new ContinueFollowingCheckTask(this);
+    }
+
+    public static class ContinueFollowingCheckTask extends Task {
+        @In
+        private PathfinderSystem pathfinderSystem;
+
+        public ContinueFollowingCheckTask(Node node) {
+            super(node);
+        }
+
+
+        @Override
+        public Status update(float dt) {
+            FollowComponent followWish = actor().getComponent(FollowComponent.class);
+            if (followWish == null) {
+                return Status.FAILURE;
+            }
+            EntityRef entityToFollow = followWish.entityToFollow;
+            if (entityToFollow == null || !entityToFollow.isActive()) {
+                return Status.FAILURE;
+            }
+            LocationComponent targetLocation = entityToFollow.getComponent(LocationComponent.class);
+            if (targetLocation == null) {
+                return Status.FAILURE;
+            }
+            Vector3f targetPoint = targetLocation.getWorldPosition();
+
+            LocationComponent currentLocation = actor().getComponent(LocationComponent.class);
+            if (currentLocation == null) {
+                return Status.FAILURE;
+            }
+            Vector3f currentPoint = currentLocation.getWorldPosition();
+
+            float minDistanceSquared = getNode().getMinDistance() * getNode().getMinDistance();
+            float maxDistanceSquared = getNode().getMaxDistance() * getNode().getMaxDistance();
+            float currentDistanceSquared = currentPoint.distanceSquared(targetPoint);
+            if (currentDistanceSquared <= minDistanceSquared) {
+                return Status.FAILURE;
+            }
+            if (currentDistanceSquared >= maxDistanceSquared) {
+                return Status.FAILURE;
+            }
+
+            return Status.SUCCESS;
+        }
+
+        @Override
+        public void handle(Status result) {
+
+        }
+
+        @Override
+        public ContinueFollowingCheckNode getNode() {
+            return (ContinueFollowingCheckNode) super.getNode();
+        }
+    }
+
+    public float getMinDistance() {
+        return minDistance;
+    }
+    public float getMaxDistance() {
+        return maxDistance;
+    }
+}

--- a/src/main/java/org/terasology/pathfinding/nodes/DamageFollowedPlayerNode.java
+++ b/src/main/java/org/terasology/pathfinding/nodes/DamageFollowedPlayerNode.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.pathfinding.nodes;
+
+import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.prefab.Prefab;
+import org.terasology.logic.behavior.tree.Node;
+import org.terasology.logic.behavior.tree.Status;
+import org.terasology.logic.behavior.tree.Task;
+import org.terasology.logic.health.DoDamageEvent;
+import org.terasology.logic.health.EngineDamageTypes;
+import org.terasology.logic.health.HealthComponent;
+import org.terasology.pathfinding.components.FollowComponent;
+import org.terasology.registry.In;
+import org.terasology.rendering.nui.properties.Range;
+
+/**
+ * Makes the character being followed take damage
+ */
+public class DamageFollowedPlayerNode extends Node {
+
+    @Range(min = 0, max = 40)
+    private int damage = 5;
+
+    @Override
+    public DamageFollowedPlayerTask createTask() {
+        return new DamageFollowedPlayerTask(this);
+    }
+
+    public static class DamageFollowedPlayerTask extends Task {
+
+        @In
+        private EntityManager entityManager;
+
+        public DamageFollowedPlayerTask(Node node) {
+            super(node);
+        }
+
+        @Override
+        public Status update(float dt) {
+            FollowComponent followComponent = actor().getComponent(FollowComponent.class);
+            if (followComponent == null) {
+                return Status.FAILURE;
+            }
+            EntityRef entityToAttack = followComponent.entityToFollow;
+            HealthComponent healthComponent = entityToAttack.getComponent(HealthComponent.class);
+            if (healthComponent == null) {
+                return Status.FAILURE;
+            }
+            Prefab damageType = EngineDamageTypes.PHYSICAL.get();
+            entityToAttack.send(new DoDamageEvent(getNode().getDamage(), damageType));
+            return Status.SUCCESS;
+        }
+
+        @Override
+        public void handle(Status result) {
+
+        }
+
+        @Override
+        public DamageFollowedPlayerNode getNode() {
+            return (DamageFollowedPlayerNode) super.getNode();
+        }
+    }
+
+    public int getDamage() {
+        return damage;
+    }
+}

--- a/src/main/java/org/terasology/pathfinding/nodes/FollowNode.java
+++ b/src/main/java/org/terasology/pathfinding/nodes/FollowNode.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.pathfinding.nodes;
+
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.logic.behavior.tree.Node;
+import org.terasology.logic.behavior.tree.Status;
+import org.terasology.logic.behavior.tree.Task;
+import org.terasology.logic.characters.CharacterMoveInputEvent;
+import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.TeraMath;
+import org.terasology.math.geom.Quat4f;
+import org.terasology.math.geom.Vector3f;
+import org.terasology.minion.move.MinionMoveComponent;
+import org.terasology.navgraph.NavGraphSystem;
+import org.terasology.navgraph.WalkableBlock;
+import org.terasology.pathfinding.componentSystem.PathfinderSystem;
+import org.terasology.pathfinding.components.FollowComponent;
+import org.terasology.pathfinding.components.NPCMovementComponent;
+import org.terasology.pathfinding.model.Path;
+import org.terasology.registry.In;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Updates the targetPosition field of the {@link NPCMovementComponent} to make it follow the entity specified by the
+ * {@link FollowComponent}. The target field does not necessarly set directly to the location of the entitiy to follow
+ * but to the next sub target on the path to the entity to follow. When the entity to follow moves, the path will be
+ * recalculated and the target gets updated.
+ *
+ * It is just a proof of concept. It will propably be later on generalized (movement to fixed point should be supported
+ * too, to avoid code duplication) and moved to the pathfinding module.
+ */
+public class FollowNode extends Node {
+
+    @Override
+    public FollowTask createTask() {
+        return new FollowTask(this);
+    }
+
+    public static class FollowTask extends Task {
+        private volatile Path nextPath;
+        private Path path;
+        private int currentIndex;
+        private boolean calculatingPath;
+
+        @In
+        private NavGraphSystem navGraphSystem;
+        @In
+        private PathfinderSystem pathfinderSystem;
+
+        public FollowTask(FollowNode node) {
+            super(node);
+        }
+
+
+        @Override
+        public void onInitialize() {
+            path = null;
+            nextPath = null;
+            currentIndex = 0;
+            calculatingPath = false;
+        }
+
+        @Override
+        public Status update(float dt) {
+            Status status = updateWithoutFailureHandling();
+            if (status == Status.FAILURE) {
+                NPCMovementComponent moveComponent = actor().getComponent(NPCMovementComponent.class);
+                moveComponent.targetPosition = null;
+                actor().save(moveComponent);
+            }
+            return status;
+        }
+
+        private Status updateWithoutFailureHandling() {
+            FollowComponent followWish = actor().getComponent(FollowComponent.class);
+            if (followWish == null) {
+                return Status.FAILURE;
+            }
+            EntityRef entityToFollow = followWish.entityToFollow;
+            if (entityToFollow == null || !entityToFollow.isActive()) {
+                return Status.FAILURE;
+            }
+            LocationComponent targetLocation = entityToFollow.getComponent(LocationComponent.class);
+            if (targetLocation == null) {
+                return Status.FAILURE;
+            }
+            Vector3f targetPosition = targetLocation.getWorldPosition();
+            WalkableBlock targetBlock = pathfinderSystem.getBlock(targetPosition);
+            if (targetBlock == null) {
+                return Status.FAILURE;
+            }
+
+            if (nextPath != null) {
+                calculatingPath = false;
+                if (nextPath == Path.INVALID) {
+                    return Status.FAILURE;
+                }
+                path = nextPath;
+                nextPath = null;
+                currentIndex = 0;
+                setTargetBasedOnPathIndex();
+            }
+
+            if ((path == null || !path.getTarget().getBlockPosition().equals(targetBlock.getBlockPosition()))
+                    && !calculatingPath) {
+                MinionMoveComponent minionMoveComponent = actor().getComponent(MinionMoveComponent.class);
+                WalkableBlock currentBlock = minionMoveComponent.currentBlock;
+                if (currentBlock == null) {
+                    return Status.FAILURE;
+                }
+                requestNextPath(targetBlock, currentBlock);
+                calculatingPath = true;
+            }
+            if (path == null) {
+                return Status.RUNNING;
+            }
+
+            if (currentIndex < path.size() && atSubTarget()) {
+                currentIndex++;
+                setTargetBasedOnPathIndex();
+            }
+            return Status.RUNNING;
+        }
+
+        private void requestNextPath(WalkableBlock targetBlock, WalkableBlock currentBlock) {
+            pathfinderSystem.requestPath(
+                    actor().getEntity(), currentBlock.getBlockPosition(),
+                    Arrays.asList(targetBlock.getBlockPosition()), new PathfinderSystem.PathReadyCallback() {
+                        @Override
+                        public void pathReady(int pathId, List<Path> path, WalkableBlock target, List<WalkableBlock> start) {
+
+                            if (path == null) {
+                                nextPath = Path.INVALID;
+                            } else if (path.size() > 0) {
+                                nextPath = path.get(0);
+                            }
+                        }
+                    });
+        }
+
+        private boolean atSubTarget() {
+            LocationComponent location = actor().getComponent(LocationComponent.class);
+            Vector3f worldPos = new Vector3f(location.getWorldPosition());
+            Vector3f targetDelta = new Vector3f();
+            targetDelta.sub(getSubTarget(), worldPos);
+            float minDistance = 0.1f;
+            return (targetDelta.x * targetDelta.x + targetDelta.z * targetDelta.z < minDistance * minDistance);
+        }
+
+        private void setTargetBasedOnPathIndex() {
+            NPCMovementComponent moveComponent = actor().getComponent(NPCMovementComponent.class);
+            if (currentIndex < path.size()) {
+                moveComponent.targetPosition = getSubTarget();
+                LocationComponent location = actor().getComponent(LocationComponent.class);
+                CharacterMoveInputEvent inputEvent = null;
+                Vector3f worldPos = new Vector3f(location.getWorldPosition());
+                Vector3f targetDirection = new Vector3f();
+                targetDirection.sub(moveComponent.targetPosition, worldPos);
+                float yaw = (float) Math.atan2(targetDirection.x, targetDirection.z);
+                moveComponent.yaw = 180f +  yaw * TeraMath.RAD_TO_DEG;
+            }else {
+                moveComponent.targetPosition = null;
+            }
+            actor().save(moveComponent);
+        }
+
+        /**
+         * Calculates the rotation around y axis according to a formula from
+         * https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles
+         */
+        private float calculateYAxisRotation(Quat4f q) {
+            return (float) Math.asin(2*(q.getX()*q.getZ() + q.getW() *q.getY()));
+        }
+
+        private Vector3f getSubTarget() {
+            WalkableBlock subTargetBlock = path.get(currentIndex);
+            Vector3f subTargetPosition = subTargetBlock.getBlockPosition().toVector3f();
+            subTargetPosition.add(new Vector3f(0, 1, 0));
+            return subTargetPosition;
+        }
+
+        @Override
+        public FollowNode getNode () {
+            return (FollowNode) super.getNode();
+        }
+
+        @Override
+        public void handle(Status result) {
+
+        }
+
+        @Override
+        public void onTerminate(Status result) {
+            NPCMovementComponent moveComponent = actor().getComponent(NPCMovementComponent.class);
+            moveComponent.targetPosition = null;
+            actor().save(moveComponent);
+        }
+    }
+
+
+
+}

--- a/src/main/java/org/terasology/pathfinding/nodes/FollowPlayerWithinRangeNode.java
+++ b/src/main/java/org/terasology/pathfinding/nodes/FollowPlayerWithinRangeNode.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.pathfinding.nodes;
+
+import com.google.common.collect.Lists;
+import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.logic.behavior.tree.Node;
+import org.terasology.logic.behavior.tree.Status;
+import org.terasology.logic.behavior.tree.Task;
+import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.geom.Vector3f;
+import org.terasology.network.ClientComponent;
+import org.terasology.pathfinding.components.FollowComponent;
+import org.terasology.registry.In;
+import org.terasology.rendering.nui.properties.Range;
+
+import java.util.List;
+
+/**
+ * Makes the character follow a player within a given range
+ */
+public class FollowPlayerWithinRangeNode extends Node {
+
+    @Range(min = 2, max = 50)
+    private float maxDistance = 15.0f;
+
+    @Override
+    public FollowPlayerWithinRangeTask createTask() {
+        return new FollowPlayerWithinRangeTask(this);
+    }
+
+    public static class FollowPlayerWithinRangeTask extends Task {
+
+        @In
+        private EntityManager entityManager;
+
+        public FollowPlayerWithinRangeTask(Node node) {
+            super(node);
+        }
+
+        @Override
+        public Status update(float dt) {
+            LocationComponent actorLocationComponent = actor().getComponent(LocationComponent.class);
+            if (actorLocationComponent == null) {
+                return Status.FAILURE;
+            }
+            Vector3f actorPosition = actorLocationComponent.getWorldPosition();
+
+            float maxDistanceSquared = getNode().getMaxDistance()*getNode().getMaxDistance();
+            Iterable<EntityRef> clients = entityManager.getEntitiesWith(ClientComponent.class);
+            List<EntityRef> charactersWithinRange = Lists.newArrayList();
+            for (EntityRef client: clients) {
+                ClientComponent clientComponent = client.getComponent(ClientComponent.class);
+                EntityRef character = clientComponent.character;
+                LocationComponent locationComponent = character.getComponent(LocationComponent.class);
+                if (locationComponent == null) {
+                    continue;
+                }
+                if (locationComponent.getWorldPosition().distanceSquared(actorPosition) <= maxDistanceSquared) {
+                    charactersWithinRange.add(character);
+                }
+            }
+
+            if (charactersWithinRange.isEmpty()) {
+                return Status.FAILURE;
+            }
+
+            FollowComponent followWish = actor().getComponent(FollowComponent.class);
+            if (followWish == null) {
+                return Status.FAILURE;
+            }
+            // TODO select closest character
+            EntityRef someCharacterWithinRange = charactersWithinRange.get(0);
+            followWish.entityToFollow = someCharacterWithinRange;
+            actor().save(followWish);
+            return Status.SUCCESS;
+        }
+
+        @Override
+        public void handle(Status result) {
+
+        }
+
+        @Override
+        public FollowPlayerWithinRangeNode getNode() {
+            return (FollowPlayerWithinRangeNode) super.getNode();
+        }
+    }
+
+    public float getMaxDistance() {
+        return maxDistance;
+    }
+}

--- a/src/main/java/org/terasology/pathfinding/nodes/SetTargetToEntityToFollowNode.java
+++ b/src/main/java/org/terasology/pathfinding/nodes/SetTargetToEntityToFollowNode.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.pathfinding.nodes;
+
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.logic.behavior.tree.Node;
+import org.terasology.logic.behavior.tree.Status;
+import org.terasology.logic.behavior.tree.Task;
+import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.geom.Vector3f;
+import org.terasology.minion.move.MinionMoveComponent;
+import org.terasology.navgraph.WalkableBlock;
+import org.terasology.pathfinding.componentSystem.PathfinderSystem;
+import org.terasology.pathfinding.components.FollowComponent;
+import org.terasology.registry.In;
+
+/**
+ * Makes the actor follow the entity specified in the {@link FollowComponent}.
+ */
+public class SetTargetToEntityToFollowNode extends Node {
+    @Override
+    public SetTargetToEntityToFollowTask createTask() {
+        return new SetTargetToEntityToFollowTask(this);
+    }
+
+    public static class SetTargetToEntityToFollowTask extends Task {
+
+        @In
+        private PathfinderSystem pathfinderSystem;
+
+        public SetTargetToEntityToFollowTask(Node node) {
+            super(node);
+        }
+
+        @Override
+        public Status update(float dt) {
+            FollowComponent followWish = actor().getComponent(FollowComponent.class);
+            if (followWish == null) {
+                return Status.FAILURE;
+            }
+            EntityRef entityToFollow = followWish.entityToFollow;
+            if (entityToFollow == null || !entityToFollow.isActive()) {
+                return Status.FAILURE;
+            }
+            LocationComponent targetLocation = entityToFollow.getComponent(LocationComponent.class);
+            if (targetLocation == null) {
+                return Status.FAILURE;
+            }
+            Vector3f position = targetLocation.getWorldPosition();
+            WalkableBlock block = pathfinderSystem.getBlock(position);
+            if (block == null) {
+                return Status.FAILURE;
+            }
+            MinionMoveComponent moveComponent = actor().getComponent(MinionMoveComponent.class);
+            moveComponent.target = block.getBlockPosition().toVector3f();
+            actor().save(moveComponent);
+            return Status.SUCCESS;
+        }
+
+        @Override
+        public void handle(Status result) {
+
+        }
+
+        @Override
+        public SetTargetToEntityToFollowNode getNode() {
+            return (SetTargetToEntityToFollowNode) super.getNode();
+        }
+    }
+}


### PR DESCRIPTION
This PR contains the components and behavior nodes used by the GooeysQuest module to create an AI for a skeleton.

Features
* The new components simulate input even when an NPC is standing to avoid the issue that it "floats away" because the movement prediction system tries to predict further movement.
* It contains nodes and components to make a NPC follow a player
* It contains nodes and components to make a NPC attack a player
* The new way of doing the pathfinding allows for interruption and correction of the path.

It is however not fully at a state where I would normally say it is a good enough API to get live. For example a lot of numbers like the attack damage value are in the behavior nodes instead of in components. Also the attack timing of the example "hostile" behavior has been picked to match the skeleton. Ideally the delay between attack animation start and damage would come from a component too.

The main reason I am making the movement from thos code fom GooeysQuests to the Pathfinding module is that some people @nihal111 is working on a improved behavior node for Deers and has the floating issue.