### PR TITLE
Simplified slope inclusion in costs

### DIFF
--- a/src/main/java/org/terasology/pathfinding/model/HAStar.java
+++ b/src/main/java/org/terasology/pathfinding/model/HAStar.java
@@ -27,7 +27,6 @@ import org.terasology.navgraph.Floor;
 import org.terasology.navgraph.WalkableBlock;
 
 import java.util.BitSet;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -54,11 +53,13 @@ public class HAStar {
     private boolean useContour;
     private LineOfSight lineOfSight;
     private boolean useSlope;
+    private final int beta;
 
     public HAStar(LineOfSight lineOfSight, boolean useContour, boolean useSlope) {
         this.useSlope = useSlope;
         this.lineOfSight = lineOfSight;
         this.useContour = useContour;
+        this.beta = 1;
         openList = new BinaryHeap((a, b) -> {
             float fA = nodes.get(a).f;
             float fB = nodes.get(b).f;
@@ -231,19 +232,18 @@ public class HAStar {
             int diffX = Math.abs(fromPos.x - toPos.x);
             int diffZ = Math.abs(fromPos.z - toPos.z);
             int diffY = Math.abs(fromPos.y - toPos.y);
-            logger.error("\n\n\n\nchecking diffY is {} \n\n\n", diffY);
             if (toNode.block.hasNeighbor(fromNode.block)) {
                 if (diffX + diffZ == 1) {
 
                     if (useSlope) {
-                        return 1 * (1 + diffY);
+                        return 1 * (1 + diffY*beta);
                     } else {
                         return 1;
                     }
 
                 } else {
                     if (useSlope) {
-                        return BitMap.SQRT_2 * (1 + diffY);
+                        return BitMap.SQRT_2 * (1 + diffY*beta);
                     } else {
                         return BitMap.SQRT_2;
                     }


### PR DESCRIPTION
# Simplified incorporation of slopes into costs.
This PR includes a very simple way of making the pathfinding algorithm include information about how steep the terrain is. If one of the paths has a route which goes uphill or downhill a lot, it will have a higher associated cost and hence will be less likely to be chosen. Thus, a path with a smoother terrain will be preferred over one which takes one which is more uneven.
For example, consider going up a hill. Generally, the path chosen will be one that goes in circles round and round untill the top. However, the previous algorithm would just choose a straight line uphill path from the foot to the top. This is not very realistic.
## TODO
Use Facets such as surfaceHeightFacet or SurfaceSteepnessFacet in order to ascertain slopes at different places
Optimise the value of beta (in HAStar currently set to 1) to obtain realistic paths. (Weighing how much going uphill or downhill actually matters. For example, it would matter a lot to a tank but not to a monkey)
Write tests