### PR TITLE
Pathfinding improvements

### DIFF
--- a/src/main/java/org/terasology/navgraph/NavGraphSystem.java
+++ b/src/main/java/org/terasology/navgraph/NavGraphSystem.java
@@ -107,13 +107,40 @@ public class NavGraphSystem extends BaseComponentSystem implements UpdateSubscri
 
     public WalkableBlock getBlock(Vector3f pos) {
         Vector3i blockPos = new Vector3i(pos.x + 0.25f, pos.y, pos.z + 0.25f);
+        blockPos.y += 2;
         WalkableBlock block = getBlock(blockPos);
         if (block == null) {
             while (blockPos.y >= (int) pos.y - 4 && block == null) {
+                if (block == null) {
+                    block = getBlock(blockPos);
+                }
+                if (block == null) {
+                    blockPos.x--;
+                    block = getBlock(blockPos);
+                    blockPos.x++;
+
+                }
+                if (block == null) {
+                    blockPos.x++;
+                    block = getBlock(blockPos);
+                    blockPos.x--;
+                }
+                if (block == null) {
+                    blockPos.z--;
+                    block = getBlock(blockPos);
+                    blockPos.z++;
+                }
+                if (block == null) {
+                    blockPos.z++;
+                    block = getBlock(blockPos);
+                    blockPos.z--;
+                }
                 blockPos.y--;
-                block = getBlock(blockPos);
+
             }
         }
+
+
         return block;
     }
 
@@ -131,13 +158,15 @@ public class NavGraphSystem extends BaseComponentSystem implements UpdateSubscri
         }
         NavGraphChunk navGraphChunk = heightMaps.remove(chunkPos);
         if (navGraphChunk != null) {
-            navGraphChunk.disconnectNeighborMaps(getNeighbor(chunkPos, -1, 0), getNeighbor(chunkPos, 0, -1), getNeighbor(chunkPos, 1, 0), getNeighbor(chunkPos, 0, 1));
+            navGraphChunk.disconnectNeighborMaps(getNeighbor(chunkPos, -1, 0), getNeighbor(chunkPos, 0, -1),
+                    getNeighbor(chunkPos, 1, 0), getNeighbor(chunkPos, 0, 1));
             navGraphChunk.cells = null;
         }
         navGraphChunk = new NavGraphChunk(world, chunkPos);
         navGraphChunk.update();
         heightMaps.put(chunkPos, navGraphChunk);
-        navGraphChunk.connectNeighborMaps(getNeighbor(chunkPos, -1, 0), getNeighbor(chunkPos, 0, -1), getNeighbor(chunkPos, 1, 0), getNeighbor(chunkPos, 0, 1));
+        navGraphChunk.connectNeighborMaps(getNeighbor(chunkPos, -1, 0), getNeighbor(chunkPos, 0, -1),
+                getNeighbor(chunkPos, 1, 0), getNeighbor(chunkPos, 0, 1));
         return navGraphChunk;
     }
 

--- a/src/main/java/org/terasology/navgraph/NavGraphSystem.java
+++ b/src/main/java/org/terasology/navgraph/NavGraphSystem.java
@@ -39,6 +39,8 @@ import org.terasology.world.chunks.event.OnChunkLoaded;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.joml.Math.round;
+
 @RegisterSystem
 @Share(value = NavGraphSystem.class)
 public class NavGraphSystem extends BaseComponentSystem implements UpdateSubscriberSystem, WorldChangeListener {
@@ -106,36 +108,28 @@ public class NavGraphSystem extends BaseComponentSystem implements UpdateSubscri
     }
 
     public WalkableBlock getBlock(Vector3f pos) {
-        Vector3i blockPos = new Vector3i(pos.x + 0.25f, pos.y, pos.z + 0.25f);
-        blockPos.y += 2;
+        Vector3i blockPos = new Vector3i(round(pos.x), round(pos.y), round(pos.z));
+        blockPos.y += 2; //Added in case the height of minion is really low
         WalkableBlock block = getBlock(blockPos);
         if (block == null) {
             while (blockPos.y >= (int) pos.y - 4 && block == null) {
                 if (block == null) {
                     block = getBlock(blockPos);
                 }
-                if (block == null) {
-                    blockPos.x--;
-                    block = getBlock(blockPos);
-                    blockPos.x++;
 
+                // Checking Neighbours as minion could be hanging on the edge of a block
+
+                for (int i = 0; i < 8; i++) {
+                    int dx = NavGraphChunk.DIRECTIONS[i][0];
+                    int dz = NavGraphChunk.DIRECTIONS[i][1];
+                    Vector3i directionVector = new Vector3i(dx, 0, dz);
+                    directionVector.add(blockPos);
+                    block = getBlock(directionVector);
+                    if (block != null) {
+                        break;
+                    }
                 }
-                if (block == null) {
-                    blockPos.x++;
-                    block = getBlock(blockPos);
-                    blockPos.x--;
-                }
-                if (block == null) {
-                    blockPos.z--;
-                    block = getBlock(blockPos);
-                    blockPos.z++;
-                }
-                if (block == null) {
-                    blockPos.z++;
-                    block = getBlock(blockPos);
-                    blockPos.z--;
-                }
-                blockPos.y--;
+
 
             }
         }


### PR DESCRIPTION
### Bug fixes
This PR lists a couple of improvements to the getBlock() function in Pathfinding which is intended to return the WalkableBlock at a specific position.
### Bug 1 
The Gooeys in MR are never actually able to calculate the path to target (Behavior returns path.INVALID) because the system is unable to locate the WalkableBlock where the gooey are present. I speculate the reason is that the heights of the Gooeys are really low and since in the original implementation of the getBlock(), it only checks all the blocks below the current pos (upto a depth of 4), it starts off underground and is never able to find a WalkableBlock. That is why, I have added the `pos+=2` to ensure that it starts off a little higher.
### Bug 2
Imagine a Gooey standing at the edge of a block that is at a height 2 (the ground is at height 0). If the gooey walked to the edge, then even if most of the gooey is actually not on the edge block at height 2, the gooey would still be at a height 2. Hence if we don't find a block at the current pos, it becomes important to check the surroundings.
