### PR TITLE
Improvements to getBlock

### DIFF
--- a/src/main/java/org/terasology/navgraph/NavGraphSystem.java
+++ b/src/main/java/org/terasology/navgraph/NavGraphSystem.java
@@ -39,6 +39,8 @@ import org.terasology.world.chunks.event.OnChunkLoaded;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.joml.Math.round;
+
 @RegisterSystem
 @Share(value = NavGraphSystem.class)
 public class NavGraphSystem extends BaseComponentSystem implements UpdateSubscriberSystem, WorldChangeListener {
@@ -106,7 +108,8 @@ public class NavGraphSystem extends BaseComponentSystem implements UpdateSubscri
     }
 
     public WalkableBlock getBlock(Vector3f pos) {
-        Vector3i blockPos = new Vector3i(pos.x + 0.25f, pos.y, pos.z + 0.25f);
+        //Vector3i blockPos = new Vector3i(pos.x + 0.25f, pos.y, pos.z + 0.25f);
+        Vector3i blockPos = new Vector3i(round(pos.x), round(pos.y) , round (pos.z));
         WalkableBlock block = getBlock(blockPos);
         if (block == null) {
             while (blockPos.y >= (int) pos.y - 4 && block == null) {

--- a/src/main/java/org/terasology/navgraph/NavGraphSystem.java
+++ b/src/main/java/org/terasology/navgraph/NavGraphSystem.java
@@ -15,6 +15,8 @@
  */
 package org.terasology.navgraph;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.biomesAPI.Biome;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
@@ -51,6 +53,8 @@ import static org.joml.Math.round;
 @Share(value = NavGraphSystem.class)
 public class NavGraphSystem extends BaseComponentSystem implements UpdateSubscriberSystem, WorldChangeListener {
     private static final float EVENT_COOLDOWN = 0.4f;
+
+    Logger logger = LoggerFactory.getLogger(NavGraphSystem.class);
 
     @In
     private WorldProvider world;

--- a/src/main/java/org/terasology/navgraph/NavGraphSystem.java
+++ b/src/main/java/org/terasology/navgraph/NavGraphSystem.java
@@ -36,9 +36,15 @@ import org.terasology.world.WorldProvider;
 import org.terasology.world.block.Block;
 import org.terasology.world.chunks.event.OnChunkLoaded;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.joml.Math.ceil;
+import static org.joml.Math.floor;
 import static org.joml.Math.round;
 
 @RegisterSystem
@@ -107,17 +113,73 @@ public class NavGraphSystem extends BaseComponentSystem implements UpdateSubscri
         return getBlock(pos);
     }
 
-    public WalkableBlock getBlock(Vector3f pos) {
-        //Vector3i blockPos = new Vector3i(pos.x + 0.25f, pos.y, pos.z + 0.25f);
-        Vector3i blockPos = new Vector3i(round(pos.x), round(pos.y) , round (pos.z));
-        WalkableBlock block = getBlock(blockPos);
-        if (block == null) {
-            while (blockPos.y >= (int) pos.y - 4 && block == null) {
-                blockPos.y--;
-                block = getBlock(blockPos);
-            }
+    /**
+     * Custom comparator that sorts the nearest blocks based on how close they are to the
+     * location of the entity
+     */
+    static class SurroundingBlockComparator implements Comparator<Vector3f> {
+        //Stores the point for which we are finding the closest blocks
+        Vector3f pos;
+
+        public SurroundingBlockComparator(Vector3f pos) {
+            this.pos = pos;
+
         }
-        return block;
+
+        @Override
+        public int compare(Vector3f o1, Vector3f o2) {
+            //Comparing distances to find out which should come before
+            if (o1.distanceSquared(pos) < o2.distanceSquared(pos)) {
+                return -1;
+            } else {
+                return 1;
+            }
+
+        }
+    }
+
+    public WalkableBlock getBlock(Vector3f pos) {
+
+        //Stores closest block
+        Vector3i blockPos = new Vector3i(round(pos.x), round(pos.y), round(pos.z));
+
+        //computing all the possible closest blocks
+        int floorValueX = (int) floor(pos.x);
+        int floorValueZ = (int) floor(pos.z);
+        int ceilValueX = (int) ceil(pos.x);
+        int ceilValueZ = (int) ceil(pos.z);
+
+        WalkableBlock block;
+
+        //ArrayList to store all the possible blockPositions around pos
+        ArrayList<Vector3f> blockPosList = new ArrayList<>();
+        blockPosList.add(new Vector3f(floorValueX, blockPos.y, floorValueZ));
+        blockPosList.add(new Vector3f(ceilValueX, blockPos.y, floorValueZ));
+        blockPosList.add(new Vector3f(floorValueX, blockPos.y, ceilValueZ));
+        blockPosList.add(new Vector3f(ceilValueX, blockPos.y, ceilValueZ));
+
+        //Sorting the ArrayList based on the custom comparator defined above
+        Collections.sort(blockPosList, new SurroundingBlockComparator(pos));
+
+
+        while (blockPos.y >= (int) pos.y - 4) {
+
+            for (Vector3f blockPosition : blockPosList) {
+
+                //iterating through the block positions based on proximity to pos
+
+                block = getBlock(new Vector3i(round(blockPosition.x), blockPos.y, round(blockPosition.z)));
+                if (block != null) {
+                    return block;
+                }
+
+            }
+
+            blockPos.y--;
+
+        }
+
+        return null;
     }
 
     public void offer(NavGraphTask task) {
@@ -134,13 +196,15 @@ public class NavGraphSystem extends BaseComponentSystem implements UpdateSubscri
         }
         NavGraphChunk navGraphChunk = heightMaps.remove(chunkPos);
         if (navGraphChunk != null) {
-            navGraphChunk.disconnectNeighborMaps(getNeighbor(chunkPos, -1, 0), getNeighbor(chunkPos, 0, -1), getNeighbor(chunkPos, 1, 0), getNeighbor(chunkPos, 0, 1));
+            navGraphChunk.disconnectNeighborMaps(getNeighbor(chunkPos, -1, 0), getNeighbor(chunkPos, 0, -1),
+                    getNeighbor(chunkPos, 1, 0), getNeighbor(chunkPos, 0, 1));
             navGraphChunk.cells = null;
         }
         navGraphChunk = new NavGraphChunk(world, chunkPos);
         navGraphChunk.update();
         heightMaps.put(chunkPos, navGraphChunk);
-        navGraphChunk.connectNeighborMaps(getNeighbor(chunkPos, -1, 0), getNeighbor(chunkPos, 0, -1), getNeighbor(chunkPos, 1, 0), getNeighbor(chunkPos, 0, 1));
+        navGraphChunk.connectNeighborMaps(getNeighbor(chunkPos, -1, 0), getNeighbor(chunkPos, 0, -1),
+                getNeighbor(chunkPos, 1, 0), getNeighbor(chunkPos, 0, 1));
         return navGraphChunk;
     }
 


### PR DESCRIPTION
This PR tries to adress several problems with the getBlock() function in Pathfinding that is core to how paths are generated and also to various Behavior Nodes

### Issues that the PR addresses

- Getting the wrong block even on flat ground.
![Terasology-200731004007-1368x713](https://user-images.githubusercontent.com/35196657/88964398-f4c30300-d2c6-11ea-95dd-2c2b09e66271.png)
In the debug overlay, (Not shown in the screenie), the position has an X coordinate of -10.41. However, the block that is chosen by the function is the one with an X coordinate of -11. It can also be slightly seen that the left block should be the block that should be chosen. The erroneous line seems to be 
`Vector3i blockPos = new Vector3i(pos.x + 0.25f, pos.y, pos.z + 0.25f);` 
The author of the line might have some other idea in mind, but I am unable to see it. With that said, I feel the change definitely makes the system work better.
- Issue with extents.
![Terasology-200731004029-1368x713](https://user-images.githubusercontent.com/35196657/88964744-6ef38780-d2c7-11ea-8128-f17984d4e266.png)
You can see in the screenie that even though, the character is 2 blocks high, the output of findBlock() selects a block that is lower. This happens because, in the previous version, only the blocks directly underneath were checked (untill a non null value of block was found). This is wrong because a character hanging from the side of a block (like me in the screenie) would receive a wrong answer. Hence it is essential to also check the surrounding blocks. The order in which the surrounding blocks are checked is also essential. I have tried to implement a custom comparator that checks the blocks in the order of their distances to the location of the entity, ie, the closest block is checked first and then so on.

### Some issues left unresolved
![Terasology-200731003109-1368x713](https://user-images.githubusercontent.com/35196657/88965193-0527ad80-d2c8-11ea-8068-a6adf8caa37a.png)
You can see in the screenie how even though I am on the ground, the block that is at a height 1, is highlighted. This happens because for floating cubes, the position field points to the feet which are actually hovering above. I don't really see any other fix other than creating a field in the MinionMoveComponent that stores the distance between the feet and the ground. With this, we can also get rid of the need to check the blocks underneath.

### Testing Instructions
Open up TutorialPathfinding with the branch improvement/FindBlock. On spawn, you should see a group of 3 yellow flower items  in your inventory. The third of this group is the findBlock() item. It highlights the output of findBlock() at the player's location with a pink colour when activated using a right click.  Make different structures and try to see if the output is correct. 