### PR TITLE
Added fixes to existing tests.

### DIFF
--- a/src/main/java/org/terasology/pathfinding/PathfinderTestGenerator.java
+++ b/src/main/java/org/terasology/pathfinding/PathfinderTestGenerator.java
@@ -15,9 +15,15 @@
  */
 package org.terasology.pathfinding;
 
+import org.terasology.assets.Asset;
+import org.terasology.assets.ResourceUrn;
+import org.terasology.assets.management.AssetManager;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockManager;
+import org.terasology.world.block.family.SymmetricFamily;
+import org.terasology.world.block.loader.BlockFamilyDefinition;
+import org.terasology.world.block.loader.BlockFamilyDefinitionData;
 import org.terasology.world.chunks.ChunkConstants;
 import org.terasology.world.chunks.CoreChunk;
 import org.terasology.world.generator.ChunkGenerationPass;
@@ -51,8 +57,13 @@ public class PathfinderTestGenerator implements ChunkGenerationPass {
     @Override
     public void generateChunk(CoreChunk chunk) {
         BlockManager blockManager = CoreRegistry.get(BlockManager.class);
+        AssetManager assetManager = CoreRegistry.get(AssetManager.class);
         air = blockManager.getBlock(BlockManager.AIR_ID);
-        ground = blockManager.getBlock("CoreBlocks:Dirt");
+        BlockFamilyDefinitionData data = new BlockFamilyDefinitionData();
+        data.setBlockFamily(SymmetricFamily.class);
+        assetManager.loadAsset(new ResourceUrn("temp:ground"), data, BlockFamilyDefinition.class);
+        ground = blockManager.getBlock("temp:ground");
+        ground.setPenetrable(false);
 
         generateLevel(chunk, 50);
 

--- a/src/test/java/org/terasology/TextWorldBuilder.java
+++ b/src/test/java/org/terasology/TextWorldBuilder.java
@@ -15,11 +15,16 @@
  */
 package org.terasology;
 
+import org.terasology.assets.ResourceUrn;
+import org.terasology.assets.management.AssetManager;
 import org.terasology.math.geom.Vector3i;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.world.WorldProvider;
 import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockManager;
+import org.terasology.world.block.family.SymmetricFamily;
+import org.terasology.world.block.loader.BlockFamilyDefinition;
+import org.terasology.world.block.loader.BlockFamilyDefinitionData;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -38,7 +43,13 @@ public class TextWorldBuilder {
     public TextWorldBuilder(WorldProvidingHeadlessEnvironment environment) {
         world = CoreRegistry.get(WorldProvider.class);
         BlockManager blockManager = CoreRegistry.get(BlockManager.class);
-        this.ground = blockManager.getBlock("CoreBlocks:Dirt");
+        AssetManager assetManager = CoreRegistry.get(AssetManager.class);
+
+        BlockFamilyDefinitionData data = new BlockFamilyDefinitionData();
+        data.setBlockFamily(SymmetricFamily.class);
+        assetManager.loadAsset(new ResourceUrn("temp:ground"), data, BlockFamilyDefinition.class);
+        this.ground = blockManager.getBlock("temp:ground");
+        this.ground.setPenetrable(false);
         this.air = blockManager.getBlock(BlockManager.AIR_ID);
     }
 


### PR DESCRIPTION
### Test Fixes
The main issue seemed to be with prefabs not loading properly within HeadlessEnvironments. This is linked to https://github.com/Terasology/Behaviors/issues/43  where the underlying issue also seemed to be prefabs not loading properly. The ground blocks were not being loaded properly. Thus, even though the `ChunkGenerationPass` was placing ground blocks, the pathfinder system would recognise it as a penetrable air block.

### The fix
I have created a non-penetrable block and hardcoded the loading of the asset into the `AssetManager`. It will do the job of testing Pathfinding for now, but the root cause should definitely be fixed as it would help other modules with their testing too.

### How to test
Checkout the PR. Navigate to the tests directory within pathfinding. Right-click all the individual tests and there should be an option to run the test class. You should be able to see the tests pass for all the classes.

