### PR TITLE
test: fix test failing due to wrong mocking

### DIFF
--- a/src/test/java/org/terasology/pathfinding/PathfinderSystemTest.java
+++ b/src/test/java/org/terasology/pathfinding/PathfinderSystemTest.java
@@ -50,7 +50,9 @@ public class PathfinderSystemTest {
         EntityRef entityRef = entityManager.create();
         entityRef.addComponent(new CharacterComponent());
 
-        navGraphSystem.chunkReady(mock(OnChunkLoaded.class), entityRef);
+        OnChunkLoaded chunkLoadedDummyEvent = new OnChunkLoaded(new Vector3i());
+
+        navGraphSystem.chunkReady(chunkLoadedDummyEvent, entityRef);
         ListenableFuture f1 = pathfinderSystem.requestPath(entityRef, new Vector3i(), Lists.newArrayList(new Vector3i()));
         ListenableFuture f2 = pathfinderSystem.requestPath(entityRef, new Vector3i(), Lists.newArrayList(new Vector3i()));
         ListenableFuture f3 = pathfinderSystem.requestPath(entityRef, new Vector3i(), Lists.newArrayList(new Vector3i()));
@@ -67,10 +69,13 @@ public class PathfinderSystemTest {
     public void updateChunkAfterPathRequests() throws InterruptedException {
         EntityRef entityRef = entityManager.create();
         entityRef.addComponent(new CharacterComponent());
+
+        OnChunkLoaded chunkLoadedDummyEvent = new OnChunkLoaded(new Vector3i());
+
         ListenableFuture f1 = pathfinderSystem.requestPath(entityRef, new Vector3i(), Lists.newArrayList(new Vector3i()));
         ListenableFuture f2 = pathfinderSystem.requestPath(entityRef, new Vector3i(), Lists.newArrayList(new Vector3i()));
         ListenableFuture f3 = pathfinderSystem.requestPath(entityRef, new Vector3i(), Lists.newArrayList(new Vector3i()));
-        navGraphSystem.chunkReady(mock(OnChunkLoaded.class), entityRef);
+        navGraphSystem.chunkReady(chunkLoadedDummyEvent, entityRef);
         while (pathfinderSystem.getPathsSearched() != 3) {
             Thread.sleep(50);
             eventSystem.process();


### PR DESCRIPTION
Tests are failing with NPE on some JOML vectors. This is because we mocked a class which did not return a value then. Can easily be fixed by not mocking the class but using a dummy instead...

![image](https://user-images.githubusercontent.com/1448874/113435237-b005e380-93e2-11eb-95f8-3fac629df696.png)

