### PR TITLE
test: port to ModuleTestingEnvironment from HeadlessEnvironment

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -8,7 +8,7 @@
         { "id": "BiomesAPI", "minVersion": "4.0.0" },
         { "id": "CoreAssets", "minVersion": "2.0.1" },
         { "id": "CoreWorlds", "minVersion": "1.1.0", "maxVersion": "3.0.0" },
-        { "id": "ModuleTestingEnvironment", "minVersion": "0.3.0", "optional": "true" }
+        { "id": "ModuleTestingEnvironment", "minVersion": "0.3.1", "optional": "true" }
     ],
     "isServerSideOnly": true,
     "isLibrary": true

--- a/module.txt
+++ b/module.txt
@@ -7,7 +7,8 @@
     "dependencies": [
         { "id": "BiomesAPI", "minVersion": "4.0.0" },
         { "id": "CoreAssets", "minVersion": "2.0.1" },
-        { "id": "CoreWorlds", "minVersion": "1.1.0", "maxVersion": "3.0.0" }
+        { "id": "CoreWorlds", "minVersion": "1.1.0", "maxVersion": "3.0.0" },
+        { "id": "ModuleTestingEnvironment", "minVersion": "0.3.0", "optional": "true" }
     ],
     "isServerSideOnly": true,
     "isLibrary": true

--- a/src/test/java/org/terasology/TextWorldBuilder.java
+++ b/src/test/java/org/terasology/TextWorldBuilder.java
@@ -1,11 +1,9 @@
-// Copyright 2020 The Terasology Foundation
+// Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology;
 
 import org.joml.Vector3i;
-import org.terasology.gestalt.assets.ResourceUrn;
-import org.terasology.gestalt.assets.management.AssetManager;
-import org.terasology.engine.WorldProvidingHeadlessEnvironment;
+import org.terasology.engine.context.Context;
 import org.terasology.engine.registry.CoreRegistry;
 import org.terasology.engine.world.WorldProvider;
 import org.terasology.engine.world.block.Block;
@@ -13,6 +11,8 @@ import org.terasology.engine.world.block.BlockManager;
 import org.terasology.engine.world.block.family.SymmetricFamily;
 import org.terasology.engine.world.block.loader.BlockFamilyDefinition;
 import org.terasology.engine.world.block.loader.BlockFamilyDefinitionData;
+import org.terasology.gestalt.assets.ResourceUrn;
+import org.terasology.gestalt.assets.management.AssetManager;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,7 +28,7 @@ public class TextWorldBuilder {
     private Block ground;
     private Block air;
 
-    public TextWorldBuilder(WorldProvidingHeadlessEnvironment environment) {
+    public TextWorldBuilder(Context context) {
         world = CoreRegistry.get(WorldProvider.class);
         BlockManager blockManager = CoreRegistry.get(BlockManager.class);
         AssetManager assetManager = CoreRegistry.get(AssetManager.class);
@@ -39,6 +39,10 @@ public class TextWorldBuilder {
         this.ground = blockManager.getBlock("temp:ground");
         this.ground.setPenetrable(false);
         this.air = blockManager.getBlock(BlockManager.AIR_ID);
+    }
+
+    public TextWorldBuilder() {
+        this(null);
     }
 
     public void setGround(int x, int y, int z) {

--- a/src/test/java/org/terasology/TextWorldBuilder.java
+++ b/src/test/java/org/terasology/TextWorldBuilder.java
@@ -40,11 +40,6 @@ public class TextWorldBuilder {
         this.air = blockManager.getBlock(BlockManager.AIR_ID);
     }
 
-    @Deprecated
-    public TextWorldBuilder() {
-        this(null);
-    }
-
     public void setGround(int x, int y, int z) {
         world.setBlock(new Vector3i(x, y, z), ground);
     }

--- a/src/test/java/org/terasology/TextWorldBuilder.java
+++ b/src/test/java/org/terasology/TextWorldBuilder.java
@@ -4,7 +4,6 @@ package org.terasology;
 
 import org.joml.Vector3i;
 import org.terasology.engine.context.Context;
-import org.terasology.engine.registry.CoreRegistry;
 import org.terasology.engine.world.WorldProvider;
 import org.terasology.engine.world.block.Block;
 import org.terasology.engine.world.block.BlockManager;
@@ -29,9 +28,9 @@ public class TextWorldBuilder {
     private Block air;
 
     public TextWorldBuilder(Context context) {
-        world = CoreRegistry.get(WorldProvider.class);
-        BlockManager blockManager = CoreRegistry.get(BlockManager.class);
-        AssetManager assetManager = CoreRegistry.get(AssetManager.class);
+        world = context.get(WorldProvider.class);
+        BlockManager blockManager = context.get(BlockManager.class);
+        AssetManager assetManager = context.get(AssetManager.class);
 
         BlockFamilyDefinitionData data = new BlockFamilyDefinitionData();
         data.setBlockFamily(SymmetricFamily.class);
@@ -41,6 +40,7 @@ public class TextWorldBuilder {
         this.air = blockManager.getBlock(BlockManager.AIR_ID);
     }
 
+    @Deprecated
     public TextWorldBuilder() {
         this(null);
     }

--- a/src/test/java/org/terasology/navgraph/ConnectNavGraphChunkTest.java
+++ b/src/test/java/org/terasology/navgraph/ConnectNavGraphChunkTest.java
@@ -3,16 +3,17 @@
 package org.terasology.navgraph;
 
 import org.joml.Vector3i;
+import org.joml.Vector3ic;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.terasology.TextWorldBuilder;
-import org.terasology.core.world.generator.AbstractBaseWorldGenerator;
-import org.terasology.engine.WorldProvidingHeadlessEnvironment;
-import org.terasology.engine.core.SimpleUri;
-import org.terasology.engine.registry.CoreRegistry;
+import org.terasology.engine.context.Context;
 import org.terasology.engine.world.WorldProvider;
-import org.terasology.gestalt.naming.Name;
-import org.terasology.pathfinding.PathfinderTestGenerator;
+import org.terasology.moduletestingenvironment.MTEExtension;
+import org.terasology.moduletestingenvironment.ModuleTestingHelper;
+import org.terasology.moduletestingenvironment.extension.Dependencies;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -24,7 +25,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * @author synopia
  */
+@Tag("MteTest")
+@ExtendWith(MTEExtension.class)
+@Dependencies("Pathfinding")
 public class ConnectNavGraphChunkTest {
+    TextWorldBuilder builder;
+    WorldProvider world;
+    Vector3ic chunkLocation = new Vector3i(0, 0, 0);
+
     private static final String[] CONTOUR_EXPECTED = new String[]{
             "               C                ",
             "                                ",
@@ -59,9 +67,6 @@ public class ConnectNavGraphChunkTest {
             "                                ",
             "                C               ",
     };
-
-    private WorldProvider world;
-    private TextWorldBuilder builder;
 
     @Test
     public void test1() {
@@ -126,16 +131,10 @@ public class ConnectNavGraphChunkTest {
     }
 
     @BeforeEach
-    public void setup() {
-        WorldProvidingHeadlessEnvironment env = new WorldProvidingHeadlessEnvironment(new Name("Pathfinding"));
-        env.setupWorldProvider(new AbstractBaseWorldGenerator(new SimpleUri("")) {
-            @Override
-            public void initialize() {
-                register(new PathfinderTestGenerator());
-            }
-        });
-        builder = new TextWorldBuilder();
-        world = CoreRegistry.get(WorldProvider.class);
+    public void setup(Context context, WorldProvider worldProvider, ModuleTestingHelper mteHelp) {
+        builder = new TextWorldBuilder(context);
+        world = worldProvider;
+        mteHelp.forceAndWaitForGeneration(chunkLocation);
     }
 
     private void assertCenter(final NavGraphChunk center, NavGraphChunk left, NavGraphChunk up, NavGraphChunk right, NavGraphChunk down, String[] contours) {

--- a/src/test/java/org/terasology/navgraph/ConnectNavGraphChunkTest.java
+++ b/src/test/java/org/terasology/navgraph/ConnectNavGraphChunkTest.java
@@ -1,4 +1,4 @@
-// Copyright 2020 The Terasology Foundation
+// Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.navgraph;
 
@@ -134,7 +134,7 @@ public class ConnectNavGraphChunkTest {
                 register(new PathfinderTestGenerator());
             }
         });
-        builder = new TextWorldBuilder(env);
+        builder = new TextWorldBuilder();
         world = CoreRegistry.get(WorldProvider.class);
     }
 

--- a/src/test/java/org/terasology/navgraph/ContourFinderTest.java
+++ b/src/test/java/org/terasology/navgraph/ContourFinderTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.terasology.TextWorldBuilder;
 import org.terasology.engine.context.Context;
-import org.terasology.engine.registry.CoreRegistry;
 import org.terasology.engine.world.WorldProvider;
 import org.terasology.moduletestingenvironment.MTEExtension;
 import org.terasology.moduletestingenvironment.ModuleTestingHelper;
@@ -424,7 +423,7 @@ public class ContourFinderTest {
 
     private void assertContour(String[] ground, String[] contour) {
         builder.setGround(ground);
-        final NavGraphChunk chunk = new NavGraphChunk(CoreRegistry.get(WorldProvider.class), new Vector3i());
+        final NavGraphChunk chunk = new NavGraphChunk(worldProvider, chunkLocation);
         chunk.update();
 
         builder.parse(new TextWorldBuilder.Runner() {

--- a/src/test/java/org/terasology/navgraph/ContourFinderTest.java
+++ b/src/test/java/org/terasology/navgraph/ContourFinderTest.java
@@ -1,4 +1,4 @@
-// Copyright 2020 The Terasology Foundation
+// Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.navgraph;
 
@@ -412,7 +412,7 @@ public class ContourFinderTest {
 
             }
         });
-        TextWorldBuilder builder = new TextWorldBuilder(env);
+        TextWorldBuilder builder = new TextWorldBuilder();
         builder.setGround(ground);
         final NavGraphChunk chunk = new NavGraphChunk(CoreRegistry.get(WorldProvider.class), new Vector3i());
         chunk.update();

--- a/src/test/java/org/terasology/navgraph/ContourFinderTest.java
+++ b/src/test/java/org/terasology/navgraph/ContourFinderTest.java
@@ -3,20 +3,31 @@
 package org.terasology.navgraph;
 
 import org.joml.Vector3i;
+import org.joml.Vector3ic;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.terasology.TextWorldBuilder;
-import org.terasology.core.world.generator.AbstractBaseWorldGenerator;
-import org.terasology.engine.WorldProvidingHeadlessEnvironment;
-import org.terasology.engine.core.SimpleUri;
+import org.terasology.engine.context.Context;
 import org.terasology.engine.registry.CoreRegistry;
 import org.terasology.engine.world.WorldProvider;
-import org.terasology.gestalt.naming.Name;
+import org.terasology.moduletestingenvironment.MTEExtension;
+import org.terasology.moduletestingenvironment.ModuleTestingHelper;
+import org.terasology.moduletestingenvironment.extension.Dependencies;
 
 /**
  * @author synopia
  */
+@Tag("MteTest")
+@ExtendWith(MTEExtension.class)
+@Dependencies("Pathfinding")
 public class ContourFinderTest {
+    TextWorldBuilder builder;
+    WorldProvider worldProvider;
+    Vector3ic chunkLocation = new Vector3i(0, 0, 0);
+
     @Test
     public void testStairs() {
         assertContour(new String[]{
@@ -404,15 +415,14 @@ public class ContourFinderTest {
         });
     }
 
-    private void assertContour(String[] ground, String[] contour) {
-        WorldProvidingHeadlessEnvironment env = new WorldProvidingHeadlessEnvironment(new Name("Pathfinding"));
-        env.setupWorldProvider(new AbstractBaseWorldGenerator(new SimpleUri("")) {
-            @Override
-            public void initialize() {
+    @BeforeEach
+    public void setup(Context context, WorldProvider worldProvider, ModuleTestingHelper mteHelp) {
+        builder = new TextWorldBuilder(context);
+        this.worldProvider = worldProvider;
+        mteHelp.forceAndWaitForGeneration(chunkLocation);
+    }
 
-            }
-        });
-        TextWorldBuilder builder = new TextWorldBuilder();
+    private void assertContour(String[] ground, String[] contour) {
         builder.setGround(ground);
         final NavGraphChunk chunk = new NavGraphChunk(CoreRegistry.get(WorldProvider.class), new Vector3i());
         chunk.update();

--- a/src/test/java/org/terasology/navgraph/FloorFinderTest.java
+++ b/src/test/java/org/terasology/navgraph/FloorFinderTest.java
@@ -1,4 +1,4 @@
-// Copyright 2020 The Terasology Foundation
+// Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.navgraph;
 
@@ -308,7 +308,7 @@ public class FloorFinderTest {
 
             }
         });
-        TextWorldBuilder builder = new TextWorldBuilder(env);
+        TextWorldBuilder builder = new TextWorldBuilder();
         builder.setGround(data);
         final NavGraphChunk chunk = new NavGraphChunk(CoreRegistry.get(WorldProvider.class), new Vector3i());
 

--- a/src/test/java/org/terasology/navgraph/RegionFinderTest.java
+++ b/src/test/java/org/terasology/navgraph/RegionFinderTest.java
@@ -3,15 +3,18 @@
 package org.terasology.navgraph;
 
 import org.joml.Vector3i;
+import org.joml.Vector3ic;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.terasology.TextWorldBuilder;
-import org.terasology.core.world.generator.AbstractBaseWorldGenerator;
-import org.terasology.engine.WorldProvidingHeadlessEnvironment;
-import org.terasology.engine.core.SimpleUri;
-import org.terasology.engine.registry.CoreRegistry;
+import org.terasology.engine.context.Context;
 import org.terasology.engine.world.WorldProvider;
-import org.terasology.gestalt.naming.Name;
+import org.terasology.moduletestingenvironment.MTEExtension;
+import org.terasology.moduletestingenvironment.ModuleTestingHelper;
+import org.terasology.moduletestingenvironment.extension.Dependencies;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -19,7 +22,14 @@ import java.util.Set;
 /**
  * @author synopia
  */
+@Tag("MteTest")
+@ExtendWith(MTEExtension.class)
+@Dependencies("Pathfinding")
 public class RegionFinderTest {
+    TextWorldBuilder builder;
+    WorldProvider worldProvider;
+    Vector3ic chunkLocation = new Vector3i(0, 0, 0);
+
     @Test
     public void testFindRegion() {
         assertRegions(new String[]{"X"}, new String[]{"0"});
@@ -138,22 +148,21 @@ public class RegionFinderTest {
         });
     }
 
+    @BeforeEach
+    public void setup(Context context, WorldProvider worldProvider, ModuleTestingHelper mteHelp) {
+        builder = new TextWorldBuilder(context);
+        this.worldProvider = worldProvider;
+        mteHelp.forceAndWaitForGeneration(chunkLocation);
+    }
+
     private void assertRegions(String[] data, String[] regions) {
         assertRegions(data, regions, null);
     }
 
     private void assertRegions(String[] data, String[] regions, int[][] connections) {
-        WorldProvidingHeadlessEnvironment env = new WorldProvidingHeadlessEnvironment(new Name("Pathfinding"));
-        env.setupWorldProvider(new AbstractBaseWorldGenerator(new SimpleUri("")) {
-            @Override
-            public void initialize() {
-
-            }
-        });
-        TextWorldBuilder builder = new TextWorldBuilder();
         builder.setGround(data);
-        final NavGraphChunk chunk = new NavGraphChunk(CoreRegistry.get(WorldProvider.class), new Vector3i());
-        new WalkableBlockFinder(CoreRegistry.get(WorldProvider.class)).findWalkableBlocks(chunk);
+        final NavGraphChunk chunk = new NavGraphChunk(worldProvider, chunkLocation);
+        new WalkableBlockFinder(worldProvider).findWalkableBlocks(chunk);
         final FloorFinder finder = new FloorFinder();
         finder.findRegions(chunk);
         String[] actual = builder.evaluate(new TextWorldBuilder.Runner() {

--- a/src/test/java/org/terasology/navgraph/RegionFinderTest.java
+++ b/src/test/java/org/terasology/navgraph/RegionFinderTest.java
@@ -1,4 +1,4 @@
-// Copyright 2020 The Terasology Foundation
+// Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.navgraph;
 
@@ -150,7 +150,7 @@ public class RegionFinderTest {
 
             }
         });
-        TextWorldBuilder builder = new TextWorldBuilder(env);
+        TextWorldBuilder builder = new TextWorldBuilder();
         builder.setGround(data);
         final NavGraphChunk chunk = new NavGraphChunk(CoreRegistry.get(WorldProvider.class), new Vector3i());
         new WalkableBlockFinder(CoreRegistry.get(WorldProvider.class)).findWalkableBlocks(chunk);

--- a/src/test/java/org/terasology/navgraph/WalkableBlockFinderTest.java
+++ b/src/test/java/org/terasology/navgraph/WalkableBlockFinderTest.java
@@ -5,6 +5,7 @@ package org.terasology.navgraph;
 import org.joml.Vector3i;
 import org.joml.Vector3ic;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.terasology.TextWorldBuilder;
@@ -22,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * @author synopia
  */
+@Tag("MteTest")
 @ExtendWith(MTEExtension.class)
 @Dependencies("Pathfinding")
 public class WalkableBlockFinderTest {

--- a/src/test/java/org/terasology/navgraph/WalkableBlockFinderTest.java
+++ b/src/test/java/org/terasology/navgraph/WalkableBlockFinderTest.java
@@ -3,15 +3,16 @@
 package org.terasology.navgraph;
 
 import org.joml.Vector3i;
+import org.joml.Vector3ic;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.terasology.TextWorldBuilder;
-import org.terasology.core.world.generator.AbstractBaseWorldGenerator;
-import org.terasology.engine.WorldProvidingHeadlessEnvironment;
-import org.terasology.engine.core.SimpleUri;
-import org.terasology.engine.registry.CoreRegistry;
+import org.terasology.engine.context.Context;
 import org.terasology.engine.world.WorldProvider;
-import org.terasology.gestalt.naming.Name;
+import org.terasology.moduletestingenvironment.MTEExtension;
+import org.terasology.moduletestingenvironment.ModuleTestingHelper;
+import org.terasology.moduletestingenvironment.extension.Dependencies;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -21,9 +22,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * @author synopia
  */
+@ExtendWith(MTEExtension.class)
+@Dependencies("Pathfinding")
 public class WalkableBlockFinderTest {
 
-    private TextWorldBuilder builder;
+    TextWorldBuilder builder;
+    WorldProvider worldProvider;
+
+    Vector3ic chunkLocation = new Vector3i(0, 0, 0);
 
     @Test
     public void testNeighbors4() {
@@ -32,7 +38,7 @@ public class WalkableBlockFinderTest {
                 "XXX|X  |X  |",
                 "XXX|   |   |"
         );
-        final NavGraphChunk chunk = new NavGraphChunk(CoreRegistry.get(WorldProvider.class), new Vector3i());
+        final NavGraphChunk chunk = new NavGraphChunk(worldProvider, chunkLocation);
         chunk.update();
 
         WalkableBlock sut = chunk.getBlock(1, 0, 1);
@@ -51,7 +57,7 @@ public class WalkableBlockFinderTest {
                 "XX    |  X   |   X  |    X |  X  X|",
                 "XXXXXX|      |      |      |XXXXXX|"
         );
-        final NavGraphChunk chunk = new NavGraphChunk(CoreRegistry.get(WorldProvider.class), new Vector3i());
+        final NavGraphChunk chunk = new NavGraphChunk(worldProvider, chunkLocation);
         chunk.update();
 
         WalkableBlock left = chunk.getBlock(2, 1, 1);
@@ -68,7 +74,7 @@ public class WalkableBlockFinderTest {
                 "X X",
                 " X "
         );
-        final NavGraphChunk chunk = new NavGraphChunk(CoreRegistry.get(WorldProvider.class), new Vector3i());
+        final NavGraphChunk chunk = new NavGraphChunk(worldProvider, chunkLocation);
         chunk.update();
 
         WalkableBlock left = chunk.getBlock(0, 0, 1);
@@ -171,8 +177,8 @@ public class WalkableBlockFinderTest {
 
     private void assertNeighbors3x3(String... data) {
         builder.setGround(data);
-        WalkableBlockFinder finder = new WalkableBlockFinder(CoreRegistry.get(WorldProvider.class));
-        final NavGraphChunk chunk = new NavGraphChunk(CoreRegistry.get(WorldProvider.class), new Vector3i());
+        WalkableBlockFinder finder = new WalkableBlockFinder(worldProvider);
+        final NavGraphChunk chunk = new NavGraphChunk(worldProvider, chunkLocation);
         finder.findWalkableBlocks(chunk);
 
         WalkableBlock lu = chunk.getCell(0, 0).blocks.get(0);
@@ -205,8 +211,8 @@ public class WalkableBlockFinderTest {
 
     private void assertWalkableBlocks(String[] data, String[] walkable) {
         builder.setGround(data);
-        WalkableBlockFinder finder = new WalkableBlockFinder(CoreRegistry.get(WorldProvider.class));
-        final NavGraphChunk chunk = new NavGraphChunk(CoreRegistry.get(WorldProvider.class), new Vector3i());
+        WalkableBlockFinder finder = new WalkableBlockFinder(worldProvider);
+        final NavGraphChunk chunk = new NavGraphChunk(worldProvider, chunkLocation);
         finder.findWalkableBlocks(chunk);
 
         String[] evaluate = builder.evaluate(new TextWorldBuilder.Runner() {
@@ -221,14 +227,9 @@ public class WalkableBlockFinderTest {
     }
 
     @BeforeEach
-    public void setup() {
-        WorldProvidingHeadlessEnvironment env = new WorldProvidingHeadlessEnvironment(new Name("Pathfinding"));
-        env.setupWorldProvider(new AbstractBaseWorldGenerator(new SimpleUri("")) {
-            @Override
-            public void initialize() {
-
-            }
-        });
-        builder = new TextWorldBuilder();
+    public void setup(Context context, WorldProvider worldProvider, ModuleTestingHelper mteHelp) {
+        builder = new TextWorldBuilder(context);
+        this.worldProvider = worldProvider;
+        mteHelp.forceAndWaitForGeneration(chunkLocation);
     }
 }

--- a/src/test/java/org/terasology/navgraph/WalkableBlockFinderTest.java
+++ b/src/test/java/org/terasology/navgraph/WalkableBlockFinderTest.java
@@ -1,4 +1,4 @@
-// Copyright 2020 The Terasology Foundation
+// Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.navgraph;
 
@@ -229,6 +229,6 @@ public class WalkableBlockFinderTest {
 
             }
         });
-        builder = new TextWorldBuilder(env);
+        builder = new TextWorldBuilder();
     }
 }

--- a/src/test/java/org/terasology/pathfinding/HAStarLoSTest.java
+++ b/src/test/java/org/terasology/pathfinding/HAStarLoSTest.java
@@ -1,4 +1,4 @@
-// Copyright 2020 The Terasology Foundation
+// Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.pathfinding;
 
@@ -10,8 +10,8 @@ import org.junit.jupiter.api.Test;
 import org.terasology.TextWorldBuilder;
 import org.terasology.core.world.generator.AbstractBaseWorldGenerator;
 import org.terasology.engine.WorldProvidingHeadlessEnvironment;
-import org.terasology.engine.core.SimpleUri;
 import org.terasology.engine.core.PathManager;
+import org.terasology.engine.core.SimpleUri;
 import org.terasology.engine.registry.CoreRegistry;
 import org.terasology.engine.world.WorldProvider;
 import org.terasology.gestalt.naming.Name;
@@ -145,7 +145,7 @@ public class HAStarLoSTest {
 
             }
         });
-        TextWorldBuilder builder = new TextWorldBuilder(env);
+        TextWorldBuilder builder = new TextWorldBuilder();
         builder.setGround(ground);
         final NavGraphChunk chunk = new NavGraphChunk(CoreRegistry.get(WorldProvider.class), new Vector3i());
         chunk.update();

--- a/src/test/java/org/terasology/pathfinding/HAStarLoSTest.java
+++ b/src/test/java/org/terasology/pathfinding/HAStarLoSTest.java
@@ -2,19 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.pathfinding;
 
-import com.badlogic.gdx.physics.bullet.Bullet;
 import org.joml.Vector3i;
+import org.joml.Vector3ic;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.terasology.TextWorldBuilder;
-import org.terasology.core.world.generator.AbstractBaseWorldGenerator;
-import org.terasology.engine.WorldProvidingHeadlessEnvironment;
-import org.terasology.engine.core.PathManager;
-import org.terasology.engine.core.SimpleUri;
-import org.terasology.engine.registry.CoreRegistry;
+import org.terasology.engine.context.Context;
 import org.terasology.engine.world.WorldProvider;
-import org.terasology.gestalt.naming.Name;
+import org.terasology.moduletestingenvironment.MTEExtension;
+import org.terasology.moduletestingenvironment.ModuleTestingHelper;
+import org.terasology.moduletestingenvironment.extension.Dependencies;
 import org.terasology.navgraph.NavGraphChunk;
 import org.terasology.navgraph.WalkableBlock;
 import org.terasology.pathfinding.model.HAStar;
@@ -27,16 +27,15 @@ import java.util.Map;
 /**
  * @author synopia
  */
+@Tag("MteTest")
+@ExtendWith(MTEExtension.class)
+@Dependencies("Pathfinding")
 public class HAStarLoSTest {
     private WalkableBlock start;
     private WalkableBlock end;
-
-    @BeforeEach
-    public void before() throws Exception {
-        // Hack to get natives to load for bullet
-        PathManager.getInstance().useDefaultHomePath();
-        Bullet.init();
-    }
+    TextWorldBuilder builder;
+    WorldProvider worldProvider;
+    Vector3ic chunkLocation = new Vector3i(0, 0, 0);
 
     @Test
     public void flat() {
@@ -137,17 +136,16 @@ public class HAStarLoSTest {
 
     }
 
-    private void executeExample(String[] ground, String[] pathData) {
-        WorldProvidingHeadlessEnvironment env = new WorldProvidingHeadlessEnvironment(new Name("Pathfinding"));
-        env.setupWorldProvider(new AbstractBaseWorldGenerator(new SimpleUri("")) {
-            @Override
-            public void initialize() {
+    @BeforeEach
+    public void setup(Context context, WorldProvider worldProvider, ModuleTestingHelper mteHelp) {
+        builder = new TextWorldBuilder(context);
+        this.worldProvider = worldProvider;
+        mteHelp.forceAndWaitForGeneration(chunkLocation);
+    }
 
-            }
-        });
-        TextWorldBuilder builder = new TextWorldBuilder();
+    private void executeExample(String[] ground, String[] pathData) {
         builder.setGround(ground);
-        final NavGraphChunk chunk = new NavGraphChunk(CoreRegistry.get(WorldProvider.class), new Vector3i());
+        final NavGraphChunk chunk = new NavGraphChunk(worldProvider, chunkLocation);
         chunk.update();
 
         final Map<Integer, Vector3i> expected = new HashMap<Integer, Vector3i>();

--- a/src/test/java/org/terasology/pathfinding/HAStarTest.java
+++ b/src/test/java/org/terasology/pathfinding/HAStarTest.java
@@ -2,19 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.pathfinding;
 
-import com.badlogic.gdx.physics.bullet.Bullet;
 import org.joml.Vector3i;
+import org.joml.Vector3ic;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.terasology.TextWorldBuilder;
-import org.terasology.core.world.generator.AbstractBaseWorldGenerator;
-import org.terasology.engine.WorldProvidingHeadlessEnvironment;
-import org.terasology.engine.core.PathManager;
-import org.terasology.engine.core.SimpleUri;
-import org.terasology.engine.registry.CoreRegistry;
+import org.terasology.engine.context.Context;
 import org.terasology.engine.world.WorldProvider;
-import org.terasology.gestalt.naming.Name;
+import org.terasology.moduletestingenvironment.MTEExtension;
+import org.terasology.moduletestingenvironment.ModuleTestingHelper;
+import org.terasology.moduletestingenvironment.extension.Dependencies;
+import org.terasology.moduletestingenvironment.extension.UseWorldGenerator;
 import org.terasology.navgraph.NavGraphChunk;
 import org.terasology.navgraph.WalkableBlock;
 import org.terasology.pathfinding.model.HAStar;
@@ -27,15 +28,22 @@ import java.util.Map;
 /**
  * @author synopia
  */
+@Tag("MteTest")
+@ExtendWith(MTEExtension.class)
+@Dependencies("Pathfinding")
+@UseWorldGenerator("ModuleTestingEnvironment:empty")
 public class HAStarTest {
     private WalkableBlock start;
     private WalkableBlock end;
+    TextWorldBuilder builder;
+    NavGraphChunk chunk;
+    Vector3ic chunkLocation = new Vector3i(0, 0, 0);
 
     @BeforeEach
-    public void before() throws Exception {
-        // Hack to get natives to load for bullet
-        PathManager.getInstance().useDefaultHomePath();
-        Bullet.init();
+    public void newWorldBuilder(Context context, WorldProvider worldProvider, ModuleTestingHelper mteHelp) {
+        builder = new TextWorldBuilder(context);
+        chunk = new NavGraphChunk(worldProvider, chunkLocation);
+        mteHelp.forceAndWaitForGeneration(chunkLocation);
     }
 
     @Test
@@ -115,16 +123,7 @@ public class HAStarTest {
 
 
     private void executeExample(String[] ground, String[] pathData) {
-        WorldProvidingHeadlessEnvironment env = new WorldProvidingHeadlessEnvironment(new Name("Pathfinding"));
-        env.setupWorldProvider(new AbstractBaseWorldGenerator(new SimpleUri("")) {
-            @Override
-            public void initialize() {
-
-            }
-        });
-        TextWorldBuilder builder = new TextWorldBuilder();
         builder.setGround(ground);
-        final NavGraphChunk chunk = new NavGraphChunk(CoreRegistry.get(WorldProvider.class), new Vector3i());
         chunk.update();
 
         final Map<Integer, Vector3i> expected = new HashMap<Integer, Vector3i>();

--- a/src/test/java/org/terasology/pathfinding/HAStarTest.java
+++ b/src/test/java/org/terasology/pathfinding/HAStarTest.java
@@ -1,4 +1,4 @@
-// Copyright 2020 The Terasology Foundation
+// Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.pathfinding;
 
@@ -10,8 +10,8 @@ import org.junit.jupiter.api.Test;
 import org.terasology.TextWorldBuilder;
 import org.terasology.core.world.generator.AbstractBaseWorldGenerator;
 import org.terasology.engine.WorldProvidingHeadlessEnvironment;
-import org.terasology.engine.core.SimpleUri;
 import org.terasology.engine.core.PathManager;
+import org.terasology.engine.core.SimpleUri;
 import org.terasology.engine.registry.CoreRegistry;
 import org.terasology.engine.world.WorldProvider;
 import org.terasology.gestalt.naming.Name;
@@ -122,7 +122,7 @@ public class HAStarTest {
 
             }
         });
-        TextWorldBuilder builder = new TextWorldBuilder(env);
+        TextWorldBuilder builder = new TextWorldBuilder();
         builder.setGround(ground);
         final NavGraphChunk chunk = new NavGraphChunk(CoreRegistry.get(WorldProvider.class), new Vector3i());
         chunk.update();

--- a/src/test/java/org/terasology/pathfinding/PathfinderSystemTest.java
+++ b/src/test/java/org/terasology/pathfinding/PathfinderSystemTest.java
@@ -2,18 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.pathfinding;
 
-import com.badlogic.gdx.physics.bullet.Bullet;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ListenableFuture;
 import org.joml.Vector3i;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.terasology.core.world.generator.AbstractBaseWorldGenerator;
-import org.terasology.engine.WorldProvidingHeadlessEnvironment;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.terasology.engine.core.ComponentSystemManager;
-import org.terasology.engine.core.SimpleUri;
-import org.terasology.engine.core.PathManager;
 import org.terasology.engine.entitySystem.entity.EntityManager;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.entitySystem.entity.internal.PojoEntityManager;
@@ -21,6 +16,8 @@ import org.terasology.engine.entitySystem.event.internal.EventSystem;
 import org.terasology.engine.logic.characters.CharacterComponent;
 import org.terasology.engine.registry.CoreRegistry;
 import org.terasology.engine.world.chunks.event.OnChunkLoaded;
+import org.terasology.moduletestingenvironment.MTEExtension;
+import org.terasology.moduletestingenvironment.extension.Dependencies;
 import org.terasology.navgraph.NavGraphSystem;
 import org.terasology.pathfinding.componentSystem.PathfinderSystem;
 import org.terasology.pathfinding.model.Pathfinder;
@@ -31,19 +28,13 @@ import static org.mockito.Mockito.mock;
 /**
  * @author synopia
  */
+@ExtendWith(MTEExtension.class)
+@Dependencies("Pathfinding")
 public class PathfinderSystemTest {
     private PojoEntityManager entityManager;
     private EventSystem eventSystem;
     private NavGraphSystem navGraphSystem;
     private PathfinderSystem pathfinderSystem;
-    private WorldProvidingHeadlessEnvironment environment;
-
-    @BeforeEach
-    public void before() throws Exception {
-        // Hack to get natives to load for bullet
-        PathManager.getInstance().useDefaultHomePath();
-        Bullet.init();
-    }
 
     @Test
     public void updateChunkBeforePathRequests() throws InterruptedException {
@@ -85,20 +76,8 @@ public class PathfinderSystemTest {
         assertTrue(f3.isDone());
     }
 
-    @AfterEach
-    public void teardown() throws Exception {
-        environment.close();
-    }
-
     @BeforeEach
     public void setup() {
-        environment = new WorldProvidingHeadlessEnvironment();
-        environment.setupWorldProvider(new AbstractBaseWorldGenerator(new SimpleUri("")) {
-            @Override
-            public void initialize() {
-
-            }
-        });
         entityManager = (PojoEntityManager) CoreRegistry.get(EntityManager.class);
         eventSystem = CoreRegistry.get(EventSystem.class);
         navGraphSystem = new NavGraphSystem();

--- a/src/test/java/org/terasology/pathfinding/PathfinderSystemTest.java
+++ b/src/test/java/org/terasology/pathfinding/PathfinderSystemTest.java
@@ -15,7 +15,6 @@ import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.entitySystem.entity.internal.PojoEntityManager;
 import org.terasology.engine.entitySystem.event.internal.EventSystem;
 import org.terasology.engine.logic.characters.CharacterComponent;
-import org.terasology.engine.registry.CoreRegistry;
 import org.terasology.engine.world.chunks.event.OnChunkLoaded;
 import org.terasology.moduletestingenvironment.MTEExtension;
 import org.terasology.moduletestingenvironment.extension.Dependencies;
@@ -79,12 +78,11 @@ public class PathfinderSystemTest {
     }
 
     @BeforeEach
-    public void setup() {
-        entityManager = (PojoEntityManager) CoreRegistry.get(EntityManager.class);
-        eventSystem = CoreRegistry.get(EventSystem.class);
+    public void setup(EntityManager entityManager, EventSystem eventSystem, ComponentSystemManager componentSystemManager) {
+        this.entityManager = (PojoEntityManager) entityManager;
+        this.eventSystem = eventSystem;
         navGraphSystem = new NavGraphSystem();
-        CoreRegistry.get(ComponentSystemManager.class).register(navGraphSystem);
-        CoreRegistry.put(NavGraphSystem.class, navGraphSystem);
+        componentSystemManager.register(navGraphSystem);
 
         pathfinderSystem = new PathfinderSystem() {
             @Override
@@ -92,7 +90,6 @@ public class PathfinderSystemTest {
                 return mock(Pathfinder.class);
             }
         };
-        CoreRegistry.get(ComponentSystemManager.class).register(pathfinderSystem);
-        CoreRegistry.put(PathfinderSystem.class, pathfinderSystem);
+        componentSystemManager.register(pathfinderSystem);
     }
 }

--- a/src/test/java/org/terasology/pathfinding/PathfinderSystemTest.java
+++ b/src/test/java/org/terasology/pathfinding/PathfinderSystemTest.java
@@ -1,4 +1,4 @@
-// Copyright 2020 The Terasology Foundation
+// Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.pathfinding;
 
@@ -44,9 +44,9 @@ public class PathfinderSystemTest {
         OnChunkLoaded chunkLoadedDummyEvent = new OnChunkLoaded(new Vector3i());
 
         navGraphSystem.chunkReady(chunkLoadedDummyEvent, entityRef);
-        ListenableFuture f1 = pathfinderSystem.requestPath(entityRef, new Vector3i(), Lists.newArrayList(new Vector3i()));
-        ListenableFuture f2 = pathfinderSystem.requestPath(entityRef, new Vector3i(), Lists.newArrayList(new Vector3i()));
-        ListenableFuture f3 = pathfinderSystem.requestPath(entityRef, new Vector3i(), Lists.newArrayList(new Vector3i()));
+        ListenableFuture<?> f1 = pathfinderSystem.requestPath(entityRef, new Vector3i(), Lists.newArrayList(new Vector3i()));
+        ListenableFuture<?> f2 = pathfinderSystem.requestPath(entityRef, new Vector3i(), Lists.newArrayList(new Vector3i()));
+        ListenableFuture<?> f3 = pathfinderSystem.requestPath(entityRef, new Vector3i(), Lists.newArrayList(new Vector3i()));
         while (pathfinderSystem.getPathsSearched() != 3) {
             Thread.sleep(10);
             eventSystem.process();
@@ -63,9 +63,9 @@ public class PathfinderSystemTest {
 
         OnChunkLoaded chunkLoadedDummyEvent = new OnChunkLoaded(new Vector3i());
 
-        ListenableFuture f1 = pathfinderSystem.requestPath(entityRef, new Vector3i(), Lists.newArrayList(new Vector3i()));
-        ListenableFuture f2 = pathfinderSystem.requestPath(entityRef, new Vector3i(), Lists.newArrayList(new Vector3i()));
-        ListenableFuture f3 = pathfinderSystem.requestPath(entityRef, new Vector3i(), Lists.newArrayList(new Vector3i()));
+        ListenableFuture<?> f1 = pathfinderSystem.requestPath(entityRef, new Vector3i(), Lists.newArrayList(new Vector3i()));
+        ListenableFuture<?> f2 = pathfinderSystem.requestPath(entityRef, new Vector3i(), Lists.newArrayList(new Vector3i()));
+        ListenableFuture<?> f3 = pathfinderSystem.requestPath(entityRef, new Vector3i(), Lists.newArrayList(new Vector3i()));
         navGraphSystem.chunkReady(chunkLoadedDummyEvent, entityRef);
         while (pathfinderSystem.getPathsSearched() != 3) {
             Thread.sleep(50);

--- a/src/test/java/org/terasology/pathfinding/PathfinderSystemTest.java
+++ b/src/test/java/org/terasology/pathfinding/PathfinderSystemTest.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ListenableFuture;
 import org.joml.Vector3i;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.terasology.engine.core.ComponentSystemManager;
@@ -28,6 +29,7 @@ import static org.mockito.Mockito.mock;
 /**
  * @author synopia
  */
+@Tag("MteTest")
 @ExtendWith(MTEExtension.class)
 @Dependencies("Pathfinding")
 public class PathfinderSystemTest {

--- a/src/test/java/org/terasology/pathfinding/PathfinderTest.java
+++ b/src/test/java/org/terasology/pathfinding/PathfinderTest.java
@@ -5,6 +5,7 @@ package org.terasology.pathfinding;
 import org.joml.Vector3i;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.terasology.TextWorldBuilder;
@@ -22,6 +23,7 @@ import org.terasology.pathfinding.model.Pathfinder;
 /**
  * @author synopia
  */
+@Tag("MteTest")
 @ExtendWith(MTEExtension.class)
 @Dependencies("Pathfinding")
 @UseWorldGenerator("Pathfinding:pathfinder")
@@ -32,14 +34,6 @@ public class PathfinderTest {
 
     @BeforeEach
     public void setup(Context context) {
-        // FIXME / Work in Progress: Need to re-install this bit
-//        env.setupWorldProvider(new AbstractBaseWorldGenerator(new SimpleUri("")) {
-//            @Override
-//            public void initialize() {
-//                register(new PathfinderTestGenerator(true));
-//            }
-//        });
-
         builder = new TextWorldBuilder(context);
 
         world = new NavGraphSystem();

--- a/src/test/java/org/terasology/pathfinding/PathfinderTest.java
+++ b/src/test/java/org/terasology/pathfinding/PathfinderTest.java
@@ -1,19 +1,18 @@
-// Copyright 2020 The Terasology Foundation
+// Copyright 2021 The Terasology Foundation
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.pathfinding;
 
-import com.badlogic.gdx.physics.bullet.Bullet;
 import org.joml.Vector3i;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.terasology.TextWorldBuilder;
-import org.terasology.core.world.generator.AbstractBaseWorldGenerator;
-import org.terasology.engine.WorldProvidingHeadlessEnvironment;
-import org.terasology.engine.core.SimpleUri;
-import org.terasology.engine.core.PathManager;
+import org.terasology.engine.context.Context;
 import org.terasology.engine.registry.InjectionHelper;
-import org.terasology.gestalt.naming.Name;
+import org.terasology.moduletestingenvironment.MTEExtension;
+import org.terasology.moduletestingenvironment.extension.Dependencies;
+import org.terasology.moduletestingenvironment.extension.UseWorldGenerator;
 import org.terasology.navgraph.NavGraphChunk;
 import org.terasology.navgraph.NavGraphSystem;
 import org.terasology.navgraph.WalkableBlock;
@@ -23,16 +22,30 @@ import org.terasology.pathfinding.model.Pathfinder;
 /**
  * @author synopia
  */
+@ExtendWith(MTEExtension.class)
+@Dependencies("Pathfinding")
+@UseWorldGenerator("Pathfinding:pathfinder")
 public class PathfinderTest {
     private Pathfinder pathfinder;
     private NavGraphSystem world;
     private TextWorldBuilder builder;
 
     @BeforeEach
-    public void before() throws Exception {
-        // Hack to get natives to load for bullet
-        PathManager.getInstance().useDefaultHomePath();
-        Bullet.init();
+    public void setup(Context context) {
+        // FIXME / Work in Progress: Need to re-install this bit
+//        env.setupWorldProvider(new AbstractBaseWorldGenerator(new SimpleUri("")) {
+//            @Override
+//            public void initialize() {
+//                register(new PathfinderTestGenerator(true));
+//            }
+//        });
+
+        builder = new TextWorldBuilder(context);
+
+        world = new NavGraphSystem();
+        InjectionHelper.inject(world);
+
+        pathfinder = new Pathfinder(world, null);
     }
 
     @Test
@@ -96,22 +109,4 @@ public class PathfinderTest {
         path = pathfinder.findPath(targetBlock, startBlock);
         Assertions.assertTrue(0 < path.size());
     }
-
-    @BeforeEach
-    public void setup() {
-        WorldProvidingHeadlessEnvironment env = new WorldProvidingHeadlessEnvironment(new Name("Pathfinding"));
-        env.setupWorldProvider(new AbstractBaseWorldGenerator(new SimpleUri("")) {
-            @Override
-            public void initialize() {
-                register(new PathfinderTestGenerator(true));
-            }
-        });
-        builder = new TextWorldBuilder(env);
-
-        world = new NavGraphSystem();
-        InjectionHelper.inject(world);
-
-        pathfinder = new Pathfinder(world, null);
-    }
-
 }


### PR DESCRIPTION
fixes #63

The easy cases look like this: [`fb53403`](https://github.com/Terasology/Pathfinding/pull/64/commits/fb5340342e21107c768d0c11f08c7a20f7b99979). Remove references to WorldProvidingHeadlessEnvironment, add the usual annotations for MTEExtension.

Tests also need to call `forceAndWaitForGeneration` before they place blocks; see https://github.com/Terasology/Pathfinding/pull/64#issuecomment-886228924